### PR TITLE
naive readline support

### DIFF
--- a/planck-cljs/src/planck/io.cljs
+++ b/planck-cljs/src/planck/io.cljs
@@ -11,3 +11,8 @@
   [filename content]
   (js/PLANCK_WRITE_FILE filename content)
   nil)
+
+(defn readline
+  "Reads a line from standard in"
+  []
+  (js/PLANCK_READ_LINE))

--- a/planck/Planck.m
+++ b/planck/Planck.m
@@ -194,6 +194,17 @@
         // supressing
     };
     
+    context[@"PLANCK_READ_LINE"] = ^() {
+        NSFileHandle *input = [NSFileHandle fileHandleWithStandardInput];
+        NSData *inputData = [input availableData];
+        NSString *inputString = nil;
+        if (0 != [inputData length]) {
+            inputString = [[NSString alloc] initWithData: inputData encoding:NSUTF8StringEncoding];
+            inputString = [inputString stringByTrimmingCharactersInSet: [NSCharacterSet newlineCharacterSet]];
+        }
+        return inputString;
+    };
+
     [self setPrintFnsInContext:contextManager.context];
 
     // Set up the cljs.user namespace


### PR DESCRIPTION
Hope you don't mind that this doesn't work. It'd be awesome if the feature existed though!

To really use planck for shell scripting, we need to be able to read from standard in. jsc has a readline function but I couldn't figure out if there was a way to use that.

The problem with the code in this pull request is that if more than one line of data is available, it'll all come back in the same String. I'd like the output of the following program to be `(ns foo` but it's the whole program.

```clojure
(ns foo
  (:require [planck.io]))

(defn -main []
  (println (planck.io/readline)))
```

```shell
ryans-mbp:~% cat foo.cljs | ./planck -s . -m foo
WARNING: foo is a single segment namespace
(ns foo
  (:require [planck.io]))

(defn -main []
  (println (planck.io/readline)))
```

Strong work so far. This project is very exciting!