### PR TITLE
Allow repeated ordered eval arguments

### DIFF
--- a/planck.xcodeproj/project.pbxproj
+++ b/planck.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		E7FE09C31B713C70009D090C /* PLKScript.m in Sources */ = {isa = PBXBuildFile; fileRef = E7FE09C21B713C70009D090C /* PLKScript.m */; };
 		ED1CE20F1B70464F0096585B /* PLKRepl.m in Sources */ = {isa = PBXBuildFile; fileRef = ED1CE20E1B70464F0096585B /* PLKRepl.m */; };
 		ED1CE2121B7047B70096585B /* PLKCommandLine.m in Sources */ = {isa = PBXBuildFile; fileRef = ED1CE2111B7047B70096585B /* PLKCommandLine.m */; };
 		ED1CE2161B7049670096585B /* PLKExecutive.m in Sources */ = {isa = PBXBuildFile; fileRef = ED1CE2151B7049670096585B /* PLKExecutive.m */; };
@@ -32,6 +33,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		E7FE09C11B713C70009D090C /* PLKScript.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PLKScript.h; sourceTree = "<group>"; };
+		E7FE09C21B713C70009D090C /* PLKScript.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PLKScript.m; sourceTree = "<group>"; };
 		ED1CE20D1B70464F0096585B /* PLKRepl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PLKRepl.h; sourceTree = "<group>"; };
 		ED1CE20E1B70464F0096585B /* PLKRepl.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PLKRepl.m; sourceTree = "<group>"; };
 		ED1CE2101B7047B70096585B /* PLKCommandLine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PLKCommandLine.h; sourceTree = "<group>"; };
@@ -127,6 +130,8 @@
 				ED1CE2181B704FF10096585B /* PLKClojureScriptEngine.m */,
 				ED51CF741B66CC6200200417 /* CljsRuntime.h */,
 				ED51CF751B66D64D00200417 /* CljsRuntime.m */,
+				E7FE09C11B713C70009D090C /* PLKScript.h */,
+				E7FE09C21B713C70009D090C /* PLKScript.m */,
 			);
 			path = planck;
 			sourceTree = "<group>";
@@ -191,6 +196,7 @@
 				EDEEDDA41B6FE2D000DF10C1 /* ABYContextManager.m in Sources */,
 				ED51CF761B66D64D00200417 /* CljsRuntime.m in Sources */,
 				EDEEDDA51B6FE2D000DF10C1 /* ABYUtils.m in Sources */,
+				E7FE09C31B713C70009D090C /* PLKScript.m in Sources */,
 				ED4919591B6EB9520084F9C5 /* linenoise.c in Sources */,
 				ED9C14901B57C21E0092866D /* main.m in Sources */,
 				ED1CE20F1B70464F0096585B /* PLKRepl.m in Sources */,

--- a/planck/PLKCommandLine.m
+++ b/planck/PLKCommandLine.m
@@ -11,7 +11,7 @@
     // Documented options
     BOOL help = NO;
     NSString* initPath = nil;
-    NSString* evalArg = nil;
+    NSMutableArray* evalArgs = [NSMutableArray new];
     NSString* srcPath = @"src";
     NSString* mainNsName = nil;
     BOOL repl = NO;
@@ -62,7 +62,7 @@
             }
             case 'e':
             {
-                evalArg = [NSString stringWithCString:optarg encoding:NSMacOSRomanStringEncoding];
+                [evalArgs addObject:[NSString stringWithCString:optarg encoding:NSMacOSRomanStringEncoding]];
                 break;
             }
             case 's':
@@ -107,7 +107,7 @@
     
     // Argument validation
     
-    if (!initPath && !evalArg && !mainNsName && args.count==0) {
+    if (!initPath && !evalArgs && !mainNsName && args.count==0) {
         repl = YES;
     }
     
@@ -149,7 +149,7 @@
             printf("  Paths may be absolute or relative in the filesystem.\n");
         } else {
             [[[PLKExecutive alloc] init] runInit:initPath
-                                            eval:evalArg
+                                            eval:evalArgs
                                          srcPath:srcPath
                                          verbose:verbose
                                       mainNsName:mainNsName

--- a/planck/PLKCommandLine.m
+++ b/planck/PLKCommandLine.m
@@ -1,6 +1,7 @@
 #import "PLKCommandLine.h"
 #include <getopt.h>
 #import "PLKExecutive.h"
+#import "PLKScript.h"
 
 #define PLANCK_VERSION "1.3"
 
@@ -10,8 +11,7 @@
 {
     // Documented options
     BOOL help = NO;
-    NSString* initPath = nil;
-    NSMutableArray* evalArgs = [NSMutableArray new];
+    NSMutableArray* scripts = [NSMutableArray new]; // of PLKScript
     NSString* srcPath = @"src";
     NSString* mainNsName = nil;
     BOOL repl = NO;
@@ -57,12 +57,12 @@
             }
             case 'i':
             {
-                initPath = [NSString stringWithCString:optarg encoding:NSMacOSRomanStringEncoding];
+                [scripts addObject:[[PLKScript alloc] initWithPath:[NSString stringWithCString:optarg encoding:NSMacOSRomanStringEncoding]]];
                 break;
             }
             case 'e':
             {
-                [evalArgs addObject:[NSString stringWithCString:optarg encoding:NSMacOSRomanStringEncoding]];
+                [scripts addObject:[[PLKScript alloc] initWithExpression:[NSString stringWithCString:optarg encoding:NSMacOSRomanStringEncoding]]];
                 break;
             }
             case 's':
@@ -107,7 +107,7 @@
     
     // Argument validation
     
-    if (!initPath && !evalArgs && !mainNsName && args.count==0) {
+    if (scripts.count == 0 && !mainNsName && args.count==0) {
         repl = YES;
     }
     
@@ -148,15 +148,14 @@
             printf("\n");
             printf("  Paths may be absolute or relative in the filesystem.\n");
         } else {
-            [[[PLKExecutive alloc] init] runInit:initPath
-                                            eval:evalArgs
-                                         srcPath:srcPath
-                                         verbose:verbose
-                                      mainNsName:mainNsName
-                                            repl:repl
-                                         outPath:outPath
-                                   plainTerminal:plainTerminal
-                                            args:args];
+            [[[PLKExecutive alloc] init] runScripts:scripts
+                                            srcPath:srcPath
+                                            verbose:verbose
+                                         mainNsName:mainNsName
+                                               repl:repl
+                                            outPath:outPath
+                                      plainTerminal:plainTerminal
+                                               args:args];
         }
     }
     

--- a/planck/PLKExecutive.h
+++ b/planck/PLKExecutive.h
@@ -2,14 +2,13 @@
 
 @interface PLKExecutive : NSObject
 
--(void)runInit:(NSString*)initPath
-          eval:(NSArray*)evalArgs
-       srcPath:(NSString*)srcPath
-       verbose:(BOOL)verbose
-    mainNsName:(NSString*)mainNsName
-          repl:(BOOL)repl
-       outPath:(NSString*)outPath
- plainTerminal:(BOOL)plainTerminal
-          args:(NSArray*)args;
+-(void)runScripts:(NSArray*)scripts
+          srcPath:(NSString*)srcPath
+          verbose:(BOOL)verbose
+       mainNsName:(NSString*)mainNsName
+             repl:(BOOL)repl
+          outPath:(NSString*)outPath
+    plainTerminal:(BOOL)plainTerminal
+             args:(NSArray*)args;
 
 @end

--- a/planck/PLKExecutive.h
+++ b/planck/PLKExecutive.h
@@ -3,7 +3,7 @@
 @interface PLKExecutive : NSObject
 
 -(void)runInit:(NSString*)initPath
-          eval:(NSString*)evalArg
+          eval:(NSArray*)evalArgs
        srcPath:(NSString*)srcPath
        verbose:(BOOL)verbose
     mainNsName:(NSString*)mainNsName

--- a/planck/PLKExecutive.m
+++ b/planck/PLKExecutive.m
@@ -1,6 +1,7 @@
 #import "PLKExecutive.h"
 #import "PLKClojureScriptEngine.h"
 #import "PLKRepl.h"
+#import "PLKScript.h"
 
 @interface PLKExecutive()
 
@@ -10,15 +11,14 @@
 
 @implementation PLKExecutive
 
--(void)runInit:(NSString*)initPath
-          eval:(NSArray*)evalArgs
-       srcPath:(NSString*)srcPath
-       verbose:(BOOL)verbose
-    mainNsName:(NSString*)mainNsName
-          repl:(BOOL)repl
-       outPath:(NSString*)outPath
- plainTerminal:(BOOL)plainTerminal
-          args:(NSArray*)args; {
+-(void)runScripts:(NSArray*)scripts
+          srcPath:(NSString*)srcPath
+          verbose:(BOOL)verbose
+       mainNsName:(NSString*)mainNsName
+             repl:(BOOL)repl
+          outPath:(NSString*)outPath
+    plainTerminal:(BOOL)plainTerminal
+             args:(NSArray*)args; {
     
     // Set up our engine
     
@@ -26,14 +26,8 @@
     
     // Process init arguments
     
-    if (initPath) {
-        [self executeScriptAtPath:initPath];
-    }
-    
-    if (evalArgs) {
-        for (NSString *evalArg in evalArgs) {
-            [self.clojureScriptEngine executeClojureScript:evalArg expression:YES];
-        }
+    for (PLKScript *script in scripts) {
+        [self executeScript:script];
     }
     
     // Process main arguments
@@ -41,8 +35,15 @@
     if (mainNsName) {
         [self.clojureScriptEngine runMainInNs:mainNsName args:args];
     } else if (!repl && args.count > 0) {
+        PLKScript *script;
         // We treat the first arg as a path to a file to be executed (it can be '-', which means stdin)
-        [self executeScriptAtPath:args[0]];
+        NSString *path = args[0];
+        if ([path isEqualToString:@"-"]) {
+            script = [[PLKScript alloc] initWithStdIn];
+        } else {
+            script = [[PLKScript alloc] initWithPath:[self fullyQualify:path]];
+        }
+        [self executeScript:script];
     } else if (repl) {
         [[[PLKRepl alloc] init] runPlainTerminal:plainTerminal usingClojureScriptEngine:self.clojureScriptEngine];
     }
@@ -77,26 +78,9 @@
     return path;
 }
 
--(void)executeScriptAtPath:(NSString*)path
+-(void)executeScript:(PLKScript *)script
 {
-    NSString* source;
-    if ([path isEqualToString:@"-"]) {
-        NSFileHandle *input = [NSFileHandle fileHandleWithStandardInput];
-        NSData *inputData = [input readDataToEndOfFile];
-        if (inputData.length) {
-            NSString *inputString = [[NSString alloc] initWithData: inputData encoding:NSUTF8StringEncoding];
-            source = [inputString stringByTrimmingCharactersInSet: [NSCharacterSet newlineCharacterSet]];
-        }
-    } else {
-        source = [NSString stringWithContentsOfFile:[self fullyQualify:path] encoding:NSUTF8StringEncoding error:nil];
-    }
-    
-    if (source) {
-        [self.clojureScriptEngine executeClojureScript:source expression:NO];
-    } else {
-        NSLog(@"Could not read file at %@", path);
-        exit(1);
-    }
+    [self.clojureScriptEngine executeClojureScript:script.content expression:script.expression];
 }
 
 @end

--- a/planck/PLKExecutive.m
+++ b/planck/PLKExecutive.m
@@ -11,7 +11,7 @@
 @implementation PLKExecutive
 
 -(void)runInit:(NSString*)initPath
-          eval:(NSString*)evalArg
+          eval:(NSArray*)evalArgs
        srcPath:(NSString*)srcPath
        verbose:(BOOL)verbose
     mainNsName:(NSString*)mainNsName
@@ -30,8 +30,10 @@
         [self executeScriptAtPath:initPath];
     }
     
-    if (evalArg) {
-        [self.clojureScriptEngine executeClojureScript:evalArg expression:YES];
+    if (evalArgs) {
+        for (NSString *evalArg in evalArgs) {
+            [self.clojureScriptEngine executeClojureScript:evalArg expression:YES];
+        }
     }
     
     // Process main arguments

--- a/planck/PLKScript.h
+++ b/planck/PLKScript.h
@@ -1,0 +1,20 @@
+//
+//  PLKScript.h
+//  planck
+//
+//  Created by Fabian Canas on 8/4/15.
+//  Copyright (c) 2015 FikesFarm. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface PLKScript : NSObject
+
+- (instancetype)initWithPath:(NSString *)path;
+- (instancetype)initWithExpression:(NSString *)expression;
+- (instancetype)initWithStdIn;
+
+@property (nonatomic, readonly, copy) NSString *content;
+@property (nonatomic, readonly, assign, getter=isExpression) BOOL expression;
+
+@end

--- a/planck/PLKScript.m
+++ b/planck/PLKScript.m
@@ -1,0 +1,63 @@
+//
+//  PLKScript.m
+//  planck
+//
+//  Created by Fabian Canas on 8/4/15.
+//  Copyright (c) 2015 FikesFarm. All rights reserved.
+//
+
+#import "PLKScript.h"
+
+@implementation PLKScript
+
+- (instancetype)initWithPath:(NSString *)path
+{
+    self = [super init];
+    if (self == nil) {
+        return self;
+    }
+    
+    _expression = NO;
+    _content = [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:nil];
+    
+    if (_content == nil) {
+        NSLog(@"Could not read file at %@", path);
+        exit(1);
+    }
+    
+    return self;
+}
+
+- (instancetype)initWithExpression:(NSString *)expression
+{
+    self = [super init];
+    if (self == nil) {
+        return self;
+    }
+    
+    _expression = YES;
+    _content = [expression copy];
+    
+    return self;
+}
+
+- (instancetype)initWithStdIn
+{
+    self = [super init];
+    if (self == nil) {
+        return self;
+    }
+    
+    _expression = NO;
+    
+    NSFileHandle *input = [NSFileHandle fileHandleWithStandardInput];
+    NSData *inputData = [input readDataToEndOfFile];
+    if (inputData.length) {
+        NSString *inputString = [[NSString alloc] initWithData: inputData encoding:NSUTF8StringEncoding];
+        _content = [inputString stringByTrimmingCharactersInSet: [NSCharacterSet newlineCharacterSet]];
+    }
+    
+    return self;
+}
+
+@end


### PR DESCRIPTION
This is a first pass at addressing #18 

Currently, I only address `-e` arguments. If this pattern is suitable, I'd be happy to also do it for `-i`, `-s`, or any other flags you think this makes sense for.