### PR TITLE
Added clojure.shell.sh integration

### DIFF
--- a/planck-cljs/src/planck/sh.cljs
+++ b/planck-cljs/src/planck/sh.cljs
@@ -35,4 +35,4 @@
   [& args]
   (let [[cmd opts] (parse-args args)
          {:keys [in in-enc out-enc env dir]} opts]
-    (js->clj (js/PLANCK_SHELL_SH (clj->js cmd) in in-enc out-enc env dir) :keywordize-keys true)))
+    (js->clj (js/PLANCK_SHELL_SH (clj->js cmd) in in-enc out-enc (clj->js env) dir) :keywordize-keys true)))

--- a/planck-cljs/src/planck/sh.cljs
+++ b/planck-cljs/src/planck/sh.cljs
@@ -1,0 +1,38 @@
+(ns planck.sh)
+
+(def ^:dynamic *sh-dir* nil)
+(def ^:dynamic *sh-env* nil)
+
+(defn- parse-args
+  [args]
+  (let [default-encoding nil
+         default-opts {:out-enc default-encoding :in-enc default-encoding :dir *sh-dir* :env *sh-env*}
+         [cmd opts] (split-with string? args)]
+    [cmd (merge default-opts (apply hash-map opts))]))
+
+(defn sh
+  "Passes the given strings to Runtime.exec() to launch a sub-process.
+  Options are
+  :in      may be given followed by a string of one of the following formats:
+           String conforming to URL Syntax: 'file:///tmp/test.txt'
+           String pointing at an *existing* 'file: '/tmp/test.txt'
+           String with string input: 'Printing input frmo stdin with funy chars like $@ &'
+           to be fed to the sub-process's stdin.
+  :in-enc  option may be given followed by a String, used as a character
+           encoding name (for example \"UTF-8\" or \"ISO-8859-1\") to
+           convert the input string specified by the :in option to the
+           sub-process's stdin.  Defaults to UTF-8.
+  :out-enc option may be given followed by :bytes or a String. If a
+           String is given, it will be used as a character encoding
+           name (for example \"UTF-8\" or \"ISO-8859-1\") to convert
+           the sub-process's stdout to a String which is returned.
+  :env     override the process env with a map of String: String.
+  :dir     override the process dir with a String.
+  sh returns a map of
+    :exit => sub-process's exit code
+    :out  => sub-process's stdout (as String)
+    :err  => sub-process's stderr (String via platform default encoding)"
+  [& args]
+  (let [[cmd opts] (parse-args args)
+         {:keys [in in-enc out-enc env dir]} opts]
+    (js->clj (js/PLANCK_SHELL_SH (clj->js cmd) in in-enc out-enc env dir) :keywordize-keys true)))

--- a/planck.xcodeproj/project.pbxproj
+++ b/planck.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4D5064A61B70F7E100C15423 /* PLKSh.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D5064A51B70F7E100C15423 /* PLKSh.m */; };
 		ED1CE20F1B70464F0096585B /* PLKRepl.m in Sources */ = {isa = PBXBuildFile; fileRef = ED1CE20E1B70464F0096585B /* PLKRepl.m */; };
 		ED1CE2121B7047B70096585B /* PLKCommandLine.m in Sources */ = {isa = PBXBuildFile; fileRef = ED1CE2111B7047B70096585B /* PLKCommandLine.m */; };
 		ED1CE2161B7049670096585B /* PLKExecutive.m in Sources */ = {isa = PBXBuildFile; fileRef = ED1CE2151B7049670096585B /* PLKExecutive.m */; };
@@ -32,6 +33,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		4D5064A41B70F7E100C15423 /* PLKSh.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PLKSh.h; sourceTree = "<group>"; };
+		4D5064A51B70F7E100C15423 /* PLKSh.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PLKSh.m; sourceTree = "<group>"; };
 		ED1CE20D1B70464F0096585B /* PLKRepl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PLKRepl.h; sourceTree = "<group>"; };
 		ED1CE20E1B70464F0096585B /* PLKRepl.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PLKRepl.m; sourceTree = "<group>"; };
 		ED1CE2101B7047B70096585B /* PLKCommandLine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PLKCommandLine.h; sourceTree = "<group>"; };
@@ -123,6 +126,8 @@
 				ED1CE2151B7049670096585B /* PLKExecutive.m */,
 				ED1CE20D1B70464F0096585B /* PLKRepl.h */,
 				ED1CE20E1B70464F0096585B /* PLKRepl.m */,
+				4D5064A41B70F7E100C15423 /* PLKSh.h */,
+				4D5064A51B70F7E100C15423 /* PLKSh.m */,
 				ED1CE2171B704FF10096585B /* PLKClojureScriptEngine.h */,
 				ED1CE2181B704FF10096585B /* PLKClojureScriptEngine.m */,
 				ED51CF741B66CC6200200417 /* CljsRuntime.h */,
@@ -189,6 +194,7 @@
 			files = (
 				ED1CE2121B7047B70096585B /* PLKCommandLine.m in Sources */,
 				EDEEDDA41B6FE2D000DF10C1 /* ABYContextManager.m in Sources */,
+				4D5064A61B70F7E100C15423 /* PLKSh.m in Sources */,
 				ED51CF761B66D64D00200417 /* CljsRuntime.m in Sources */,
 				EDEEDDA51B6FE2D000DF10C1 /* ABYUtils.m in Sources */,
 				ED4919591B6EB9520084F9C5 /* linenoise.c in Sources */,

--- a/planck/ABYUtils.h
+++ b/planck/ABYUtils.h
@@ -5,6 +5,7 @@
  */
 @interface ABYUtils : NSObject
 
++(id)valueOfType:(Class)type fromJSValue:(JSValue*)value;
 +(NSString*)stringForValue:(JSValueRef)value inContext:(JSContextRef)context;
 +(void)setValue:(JSValueRef)value onObject:(JSObjectRef)object forProperty:(NSString*)property inContext:(JSContextRef)context;
 +(JSValueRef)getValueOnObject:(JSObjectRef)object forProperty:(NSString*)property inContext:(JSContextRef)context;

--- a/planck/ABYUtils.m
+++ b/planck/ABYUtils.m
@@ -8,6 +8,14 @@ JSValueRef BlockFunctionCallAsFunction(JSContextRef ctx, JSObjectRef function, J
 
 @implementation ABYUtils
 
+
++(id)valueOfType:(Class)type fromJSValue:(JSValue*)value
+{
+    if (value.isUndefined)return nil;
+    if (value.isNull)return nil;
+    return [value toObjectOfClass:type];
+}
+
 +(NSString*)stringForValue:(JSValueRef)value inContext:(JSContextRef)context
 {
     JSStringRef JSString = JSValueToStringCopy(context, value, NULL);

--- a/planck/PLKClojureScriptEngine.m
+++ b/planck/PLKClojureScriptEngine.m
@@ -1,4 +1,5 @@
 #import "PLKClojureScriptEngine.h"
+#import "PLKSh.h"
 #import "ABYUtils.h"
 #import "ABYContextManager.h"
 #import "CljsRuntime.h"
@@ -165,6 +166,13 @@
         self.context[@"PLANCK_PRINT_FN"] = ^(NSString *message) {
             // supressing
         };
+        
+        self.context[@"PLANCK_SHELL_SH"] = ^(NSArray *args, JSValue* arg_in, JSValue *encoding_in, JSValue *encoding_out, NSDictionary *env, JSValue *dir) {
+            #define TSTR(av) (NSString*)[ABYUtils valueOfType:[NSString class] fromJSValue:av]
+            NSDictionary *result = cljs_shell(args, TSTR(arg_in), TSTR(encoding_in), TSTR(encoding_out), env, TSTR(dir));
+            return result;
+        };
+
         
         const BOOL isTty = isatty(fileno(stdin));
         

--- a/planck/PLKSh.h
+++ b/planck/PLKSh.h
@@ -1,0 +1,33 @@
+//
+//  Sh.h
+//  planck
+//
+//  Created by Benedikt Terhechte on 04/08/15.
+//  Copyright (c) 2015 FikesFarm. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+
+/*!
+ @param args: The executable and arguments to be executed. The executable should include the full absolute path. i.e.
+   @[@"/bin/ls", @"-aul"]
+ @param arg_in: The Standard Input (optional). Can be one of the following:
+    NSString conforming to URL Syntax: "file:///tmp/test.txt"
+    NSString pointing at an *existing* "file: "/tmp/test.txt"
+    NSString with string input: "Printing input frmo stdin with funy chars like ' \" $@ &"
+    NSFileHandle: A file handle to an open file
+    NSPipe: A Pipe that can be written into from somewhere else.
+ @param encoding_in: The encoding of the Standard Input in ISO Format. I.e. "windows-1255"
+    The default is UTF8
+ @param encoding_out: The encoding of the Standard Output in ISO Format. I.e. "windows-1255"
+    The default is UTF8
+ @param env: A NSDictionary (String: String) with the Environment to be used
+ @param dir: A string defining the process dir
+ 
+ @returns NSDictionary: Returns an NSDictionary with the following keys: "out", "err" and "exit".
+    "out": NSString: The output of the command (the standard output)
+    "err": NSString: The standard error
+    "exit": NSNumber: The exit code
+ */
+NSDictionary* cljs_shell(NSArray *args, id arg_in, NSString *encoding_in, NSString *encoding_out, NSDictionary *env, NSString *dir);

--- a/planck/PLKSh.m
+++ b/planck/PLKSh.m
@@ -90,8 +90,14 @@ NSDictionary* cljs_shell(NSArray *args, id arg_in, NSString *encoding_in, NSStri
     }
     
     // We'll block during execution
-    [aTask launch];
-    [aTask waitUntilExit];
+    @try {
+        [aTask launch];
+        [aTask waitUntilExit];
+    }
+    @catch (NSException *exception) {
+        return @{@"exit": @(-1),
+                 @"err": exception.description};
+    }
     
     // Read the data from the task
     NSData *outData = [outPipe.fileHandleForReading readDataToEndOfFile];

--- a/planck/PLKSh.m
+++ b/planck/PLKSh.m
@@ -1,0 +1,111 @@
+//
+//  Sh.m
+//  planck
+//
+//  Created by Benedikt Terhechte on 04/08/15.
+//  Copyright (c) 2015 FikesFarm. All rights reserved.
+//
+
+#import "PLKSh.h"
+
+NSStringEncoding encodingFromString(NSString *encoding_in, NSStringEncoding defaultEncoding) {
+    NSStringEncoding encoding = defaultEncoding;
+    if (encoding_in) {
+        CFStringEncoding cfEncoding = CFStringConvertIANACharSetNameToEncoding((__bridge CFStringRef)encoding_in);
+        // If there was no valid encoding, continue with UTF8
+        if (cfEncoding != kCFStringEncodingInvalidId) {
+            encoding = CFStringConvertEncodingToNSStringEncoding(cfEncoding);
+        }
+    }
+    return encoding;
+}
+
+NSDictionary* cljs_shell(NSArray *args, id arg_in, NSString *encoding_in, NSString *encoding_out, NSDictionary *env, NSString *dir) {
+    
+    NSTask *aTask = [[NSTask alloc] init];
+    
+    // make sure all args are strings
+    NSMutableArray *stringArgs = @[].mutableCopy;
+    for (id argument in args)[stringArgs addObject:[NSString stringWithFormat:@"%@", argument]];
+    
+    // set the executable
+    [aTask setLaunchPath:stringArgs.firstObject];
+    
+    // Set the arguments
+    if (stringArgs.count > 1) {
+        [aTask setArguments:[stringArgs subarrayWithRange:NSMakeRange(1, stringArgs.count-1)]];
+    }
+    
+    // if we have :in, set it based on the type
+    // if arg_in is a string, see if it is a valid file path that exists, and if not, interpret it as a string
+    // if arg_in is a pipe or a file handle, use it directly
+    NSError *error = nil;
+    if (arg_in != nil) {
+        if ([arg_in isKindOfClass:[NSString class]]) {
+            NSURL *fileURL = [NSURL URLWithString:arg_in];
+            if (fileURL != nil) {
+                // The Format is an URL
+                [aTask setStandardInput: [NSFileHandle fileHandleForReadingFromURL:fileURL error:&error]];
+            } else if ([[NSFileManager defaultManager] fileExistsAtPath:arg_in isDirectory:nil]) {
+                // The args is an existing file path
+                [aTask setStandardInput: [NSFileHandle fileHandleForReadingAtPath:arg_in]];
+            } else {
+                // The args is a string
+                NSPipe *aPipe = [NSPipe pipe];
+                
+                // process the *in* encoding
+                NSStringEncoding encoding = encodingFromString(encoding_in, NSUTF8StringEncoding);
+                
+                [aPipe.fileHandleForWriting writeData:[(NSString*)arg_in dataUsingEncoding:encoding]];
+                [aPipe.fileHandleForWriting closeFile];
+                [aTask setStandardInput: aPipe];
+            }
+        }
+    } else if ([arg_in isKindOfClass:[NSPipe class]]) {
+        [aTask setStandardInput:arg_in];
+    } else if ([arg_in isKindOfClass:[NSFileHandle class]]) {
+        [aTask setStandardInput:arg_in];
+    }
+    
+    // If we had an error during arg_in setup, we fail here with the reason
+    if (error) {
+        return @{@"exit": @(-1),
+                 @"out": @"",
+                 @"err": [NSString stringWithFormat:@"Wrong argument for :in. Error: %@", error.localizedDescription]};
+    }
+    
+    // Create the error and output pipes
+    NSPipe *outPipe = [NSPipe pipe];
+    NSPipe *errPipe = [NSPipe pipe];
+    
+    [aTask setStandardError: errPipe];
+    [aTask setStandardOutput:outPipe];
+    
+    if (dir != nil) {
+        [aTask setCurrentDirectoryPath:dir];
+    }
+    
+    if (env != nil) {
+        [aTask setEnvironment:env];
+    }
+    
+    // We'll block during execution
+    [aTask launch];
+    [aTask waitUntilExit];
+    
+    // Read the data from the task
+    NSData *outData = [outPipe.fileHandleForReading readDataToEndOfFile];
+    NSData *errData = [outPipe.fileHandleForReading readDataToEndOfFile];
+    
+    NSStringEncoding encoding = encodingFromString(encoding_out, NSUTF8StringEncoding);
+    
+    // sh docs say sub-process's stdout (as byte[] or String), however we'll always return string
+    NSString *outString = [[NSString alloc] initWithData:outData encoding:encoding];
+    
+    // sub-process's stderr (String via platform default encoding)
+    NSString *errString = [[NSString alloc] initWithData:errData encoding:NSUTF8StringEncoding];
+    
+    return @{@"exit": @(aTask.terminationStatus),
+             @"out": outString,
+             @"err": errString};
+}


### PR DESCRIPTION
This pull request integrates a basic clojure.shell.sh function. Usage is as follows:

``` Clojure
(require 'planck.sh)
(planck.sh/sh "ls" "-l" :env {"variable" "value"} :dir "/tmp/")
(planck.sh/sh "cat" :in "/tmp/inputfile.txt")
```

Documentation:
 * **:in**      may be given followed by a string of one of the following formats:
           String conforming to URL Syntax: 'file:///tmp/test.txt'
           String pointing at an *existing* 'file: '/tmp/test.txt'
           String with string input: 'Printing input from stdin with funny chars like $@ &'
           to be fed to the sub-process's stdin.

*  **:in-enc**  option may be given followed by a String, used as a character
           encoding name (for example \"UTF-8\" or \"ISO-8859-1\") to
           convert the input string specified by the :in option to the
           sub-process's stdin.  Defaults to UTF-8.

*  **:out-enc** option may be given followed by :bytes or a String. If a
           String is given, it will be used as a character encoding
           name (for example \"UTF-8\" or \"ISO-8859-1\") to convert
           the sub-process's stdout to a String which is returned.

*  **:env**     override the process env with a map of String: String.

*  **:dir**     override the process dir with a String.

  sh returns a map of
 *   **:exit** => sub-process's exit code

 *   **:out**  => sub-process's stdout (as String)

 *   **:err**  => sub-process's stderr (String via platform default encoding)"

The function does it's best to figure out where the executable is located, i.e. it is not required to write `(sh "/bin/ls")`. However, in general adding the proper absolute path will improve performance and make sure that the correct executable is being used.

There's currently no way to using anything except for a string as the parameter to `:in`. The Objective-C version already supports Pipes and File Descriptors, however there's no support for this on the ClojureScript side. 

Exceptions are currently being transformed into the `err` key for the return map. I'm not sure if that's the best solution but otherwise it would crash the planck interpreter.

Cheers,
Benedikt



