### PR TITLE
Trim namespace from the value passed to print-doc (Issue 42)

### DIFF
--- a/planck-cljs/src/planck/core.cljs
+++ b/planck-cljs/src/planck/core.cljs
@@ -199,8 +199,11 @@
             doc (if (repl-specials (second expression-form))
                   (repl/print-doc (repl-special-doc (second expression-form)))
                   (repl/print-doc
-                    (let [sym (second expression-form)]
-                          (with-compiler-env st (resolve env sym))))))
+                    (let [sym (second expression-form)
+                          var (with-compiler-env st (resolve env sym))]
+                      (if (= (namespace (:name var)) (str (:ns var)))
+                        (update var :name #(symbol (name %)))
+                        var)))))
           (prn nil))
         (try
           (cljs/eval-str


### PR DESCRIPTION
Fixes an issue in which the namespace would appear twice when calling doc. If
the namespace on the :name symbol exists and is the same as the :ns symbol,
we drop the namespace value from the :name symbol before calling print-doc.

Related to CLJS-921, but the fix should not cause problems if ClojureScript's
behavior changes.