### PR TITLE
Track execution errors in *e

### DIFF
--- a/planck-cljs/src/planck/core.cljs
+++ b/planck-cljs/src/planck/core.cljs
@@ -236,4 +236,5 @@
               (when error
                 (print-error error))))
           (catch :default e
+            (set! *e e)
             (print-error e)))))))


### PR DESCRIPTION
Refs #15 

Unsure if there was a reason not to do this. 

Also in the "happy path" above I see that errors are not tracked unless `expression?` is true - should it not be regardless?