### PR TITLE
Add support for pst

### DIFF
--- a/int-test/expected/PLANCK-ERR.txt
+++ b/int-test/expected/PLANCK-ERR.txt
@@ -1,1 +1,2 @@
 hello stderr
+WARNING: Wrong number of args (3) passed to cljs.core/symbol at line 1 

--- a/int-test/expected/PLANCK-OUT.txt
+++ b/int-test/expected/PLANCK-OUT.txt
@@ -42,3 +42,45 @@ cljs.user/cljs.user/f
 ([param])
   docstring
 nil
+Test pst REPL special
+Invalid arity: 3
+	 cljs$core$symbol (cljs/core.cljs:944:1)
+
+Invalid arity: 3
+	 cljs$core$symbol (cljs/core.cljs:944:1)
+
+nil
+#'cljs.user/e
+Can't call nil at line 1 
+	 cljs$core$ExceptionInfo (cljs/core.cljs:9863:11)
+	 cljs$core$IFn$_invoke$arity$3 (cljs/core.cljs:9896:5)
+	 cljs$core$IFn$_invoke$arity$3 (cljs/analyzer.cljs:994:55)
+	 cljs$core$IFn$_invoke$arity$2 (cljs/analyzer.cljs:990:57)
+	 cljs$core$IFn$_invoke$arity$4 (cljs/analyzer.cljs:4256:56)
+	 cljs$analyzer$analyze_form (cljs/analyzer.cljs:4398:63)
+	 cljs$analyzer$analyze_STAR_ (cljs/analyzer.cljs:4436:37)
+	 cljs$core$IFn$_invoke$arity$4 (cljs/analyzer.cljs:4511:39)
+	 cljs$js$eval_str_STAR__$_compile_loop (cljs/js.cljs:1517:4)
+	 cljs$js$eval_str_STAR_ (cljs/js.cljs:1609:6)
+	 cljs$core$IFn$_invoke$arity$5 (cljs/js.cljs:1712:30)
+	 planck$core$read_eval_print (planck/core.cljs:215:12)
+
+Can't call nil at line 1 
+	 cljs$core$ExceptionInfo (cljs/core.cljs:9863:11)
+	 cljs$core$IFn$_invoke$arity$3 (cljs/core.cljs:9896:5)
+	 cljs$core$IFn$_invoke$arity$3 (cljs/analyzer.cljs:994:55)
+	 cljs$core$IFn$_invoke$arity$2 (cljs/analyzer.cljs:990:57)
+	 cljs$core$IFn$_invoke$arity$4 (cljs/analyzer.cljs:4256:56)
+	 cljs$analyzer$analyze_form (cljs/analyzer.cljs:4398:63)
+	 cljs$analyzer$analyze_STAR_ (cljs/analyzer.cljs:4436:37)
+	 cljs$core$IFn$_invoke$arity$4 (cljs/analyzer.cljs:4511:39)
+	 cljs$js$eval_str_STAR__$_compile_loop (cljs/js.cljs:1517:4)
+	 cljs$js$eval_str_STAR_ (cljs/js.cljs:1609:6)
+	 cljs$core$IFn$_invoke$arity$5 (cljs/js.cljs:1712:30)
+	 planck$core$read_eval_print (planck/core.cljs:215:12)
+
+nil
+Invalid arity: 3
+	 cljs$core$symbol (cljs/core.cljs:944:1)
+
+nil

--- a/int-test/expected/PLANCK-OUT.txt
+++ b/int-test/expected/PLANCK-OUT.txt
@@ -63,7 +63,7 @@ Can't call nil at line 1
 	 cljs$js$eval_str_STAR__$_compile_loop (cljs/js.cljs:1517:4)
 	 cljs$js$eval_str_STAR_ (cljs/js.cljs:1609:6)
 	 cljs$core$IFn$_invoke$arity$5 (cljs/js.cljs:1712:30)
-	 planck$core$read_eval_print (planck/core.cljs:215:12)
+	 planck$core$read_eval_print (planck/core.cljs:216:12)
 
 Can't call nil at line 1 
 	 cljs$core$ExceptionInfo (cljs/core.cljs:9863:11)
@@ -77,7 +77,7 @@ Can't call nil at line 1
 	 cljs$js$eval_str_STAR__$_compile_loop (cljs/js.cljs:1517:4)
 	 cljs$js$eval_str_STAR_ (cljs/js.cljs:1609:6)
 	 cljs$core$IFn$_invoke$arity$5 (cljs/js.cljs:1712:30)
-	 planck$core$read_eval_print (planck/core.cljs:215:12)
+	 planck$core$read_eval_print (planck/core.cljs:216:12)
 
 nil
 Invalid arity: 3

--- a/int-test/script/gen-actual
+++ b/int-test/script/gen-actual
@@ -47,3 +47,12 @@ $PLANCK -s $SRC <<REPL_INPUT
 (doc f)
 REPL_INPUT
 
+echo "Test pst REPL special"
+$PLANCK -s $SRC <<REPL_INPUT
+(symbol 1 2 3)
+(pst)
+(def e *e)
+(nil)
+(pst)
+(pst e)
+REPL_INPUT

--- a/planck-cljs/src/planck/core.cljs
+++ b/planck-cljs/src/planck/core.cljs
@@ -205,8 +205,9 @@
                           (with-compiler-env st (resolve env sym)))))
             pst (let [expr (or (second expression-form) '*e)]
                   (try (cljs/eval st
-                                  (list 'identity expr)
+                                  expr
                                   {:ns   @current-ns
+                                   :context :expr
                                    :eval cljs/js-eval}
                                   print-error)
                        (catch js/Error e (prn :caught e)))))

--- a/planck-cljs/src/planck/core.cljs
+++ b/planck-cljs/src/planck/core.cljs
@@ -228,22 +228,20 @@
                  :def-emits-var true}))
             (fn [{:keys [ns value error] :as ret}]
               (if expression?
-                (if-not error
-                  (do
-                    (when (or print-nil-expression?
+                (when-not error
+                  (when (or print-nil-expression?
                             (not (nil? value)))
-                      (prn value))
-                    (when-not
+                    (prn value))
+                  (when-not
                       (or ('#{*1 *2 *3 *e} expression-form)
-                        (ns-form? expression-form))
-                      (set! *3 *2)
-                      (set! *2 *1)
-                      (set! *1 value))
-                    (reset! current-ns ns)
-                    nil)
-                  (do
-                    (set! *e error))))
+                          (ns-form? expression-form))
+                    (set! *3 *2)
+                    (set! *2 *1)
+                    (set! *1 value))
+                  (reset! current-ns ns)
+                  nil))
               (when error
+                (set! *e error)
                 (print-error error))))
           (catch :default e
             (set! *e e)

--- a/planck-cljs/src/planck/core.cljs
+++ b/planck-cljs/src/planck/core.cljs
@@ -51,8 +51,7 @@
     doc            {:arglists ([name])
                     :doc      "Prints documentation for a var or special form given its name"}
     pst            {:arglists ([] [e])
-                    :doc      (str "Prints a stack trace of the exception. If none supplied, uses the root cause of the "
-                                   "most recent repl exception (*e)")}})
+                    :doc      "Prints a stack trace of the exception.\n  If none supplied, uses the root cause of the most recent repl exception (*e)"}})
 
 (defn- repl-special-doc [name-symbol]
   (assoc (repl-special-doc-map name-symbol)

--- a/planck-cljs/src/planck/core.cljs
+++ b/planck-cljs/src/planck/core.cljs
@@ -203,10 +203,13 @@
                   (repl/print-doc
                     (let [sym (second expression-form)]
                           (with-compiler-env st (resolve env sym)))))
-            pst (let [sym (or (second expression-form) '*e)]
-                  (read-eval-print (str "(planck.core/print-error " sym ")")
-                                   expression?
-                                   false)))
+            pst (let [expr (or (second expression-form) '*e)]
+                  (try (cljs/eval st
+                                  (list 'identity expr)
+                                  {:ns   @current-ns
+                                   :eval cljs/js-eval}
+                                  print-error)
+                       (catch js/Error e (prn :caught e)))))
           (prn nil))
         (try
           (cljs/eval-str

--- a/planck-cljs/src/planck/core.cljs
+++ b/planck-cljs/src/planck/core.cljs
@@ -236,4 +236,5 @@
               (when error
                 (print-error error))))
           (catch :default e
+            (set! *e e)
             (print-error e)))))))

--- a/planck-cljs/src/planck/core.cljs
+++ b/planck-cljs/src/planck/core.cljs
@@ -204,9 +204,10 @@
                   (repl/print-doc
                     (let [sym (second expression-form)]
                           (with-compiler-env st (resolve env sym)))))
-            pst (let [sym (or (-> expression-form second second) '*e)
-                      err (with-compiler-env st (resolve env sym))]
-                  (print-error err)))
+            pst (let [sym (or (second expression-form) '*e)]
+                  (read-eval-print (str "(planck.core/print-error " sym ")")
+                                   expression?
+                                   false)))
           (prn nil))
         (try
           (cljs/eval-str


### PR DESCRIPTION
This is working, but is pretty hacky and I could use help improving it

Added an optional argument to take an error, to match the API for Clojure. Where this is straight-up delegation that isn't so useful though (but perhaps that will change?)

Some short-comings:

* Abuses recursion on repl function to run generated code

* Prints spurious warnings around `plack.core` namespaces and the `planck.core/print-error` var. Assume there's a reason these are loaded but not in the analysis cache?

* Overly obscure if *e is blank (`undefined is not an object (evaluating 'error.cause')`), should print something friendlier for the user.

Is there a simple to get the value of the expression in this scope from the resolved symbol? Guessing that supporting non symbols in second position is not a priority.

Closes #15