### PR TITLE
Implemented file and file-seq

### DIFF
--- a/planck-cljs/src/planck/core.cljs
+++ b/planck-cljs/src/planck/core.cljs
@@ -302,3 +302,8 @@
           (catch :default e
             (set! *e e)
             (print-error e)))))))
+
+(defn file-seq
+  "A tree seq on PLKFiles"
+  [dir]
+  (js/PLANCK_IO_FILESEQ dir))

--- a/planck-cljs/src/planck/io.cljs
+++ b/planck-cljs/src/planck/io.cljs
@@ -173,3 +173,18 @@
   [filename content]
   (js/PLANCK_WRITE_FILE filename content)
   nil)
+
+(defn file
+  "Returns a PLKFile, passing each arg to as-file.  Multiple-arg
+   versions treat the first argument as parent and subsequent args as
+   children relative to the parent."
+  ([arg]                      
+    (js/PLANCK_IO_FILE arg))
+  ([parent & more]
+     (js/PLANCK_IO_FILE (apply str parent more))))
+
+(defn delete-file
+  "Delete file f."
+  [f]
+  (.deleteFile f))
+

--- a/planck.xcodeproj/project.pbxproj
+++ b/planck.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4D0A653E1B7B7B6F00D6EA85 /* PLKIO.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D0A653D1B7B7B6F00D6EA85 /* PLKIO.m */; };
 		E7FE09C31B713C70009D090C /* PLKScript.m in Sources */ = {isa = PBXBuildFile; fileRef = E7FE09C21B713C70009D090C /* PLKScript.m */; };
 		ED1CE20F1B70464F0096585B /* PLKRepl.m in Sources */ = {isa = PBXBuildFile; fileRef = ED1CE20E1B70464F0096585B /* PLKRepl.m */; };
 		ED1CE2121B7047B70096585B /* PLKCommandLine.m in Sources */ = {isa = PBXBuildFile; fileRef = ED1CE2111B7047B70096585B /* PLKCommandLine.m */; };
@@ -36,6 +37,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		4D0A653C1B7B7B6F00D6EA85 /* PLKIO.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PLKIO.h; sourceTree = "<group>"; };
+		4D0A653D1B7B7B6F00D6EA85 /* PLKIO.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PLKIO.m; sourceTree = "<group>"; };
 		E7FE09C11B713C70009D090C /* PLKScript.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PLKScript.h; sourceTree = "<group>"; };
 		E7FE09C21B713C70009D090C /* PLKScript.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PLKScript.m; sourceTree = "<group>"; };
 		ED1CE20D1B70464F0096585B /* PLKRepl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PLKRepl.h; sourceTree = "<group>"; };
@@ -147,6 +150,8 @@
 				ED1CE2271B72C6360096585B /* PLKFileReader.m */,
 				ED8DBF7F1B77732F00BBA2FA /* PLKFileWriter.h */,
 				ED8DBF801B77732F00BBA2FA /* PLKFileWriter.m */,
+				4D0A653C1B7B7B6F00D6EA85 /* PLKIO.h */,
+				4D0A653D1B7B7B6F00D6EA85 /* PLKIO.m */,
 			);
 			path = planck;
 			sourceTree = "<group>";
@@ -212,6 +217,7 @@
 				EDEEDDA41B6FE2D000DF10C1 /* ABYContextManager.m in Sources */,
 				EDEEDDA51B6FE2D000DF10C1 /* ABYUtils.m in Sources */,
 				ED8DBF811B77732F00BBA2FA /* PLKFileWriter.m in Sources */,
+				4D0A653E1B7B7B6F00D6EA85 /* PLKIO.m in Sources */,
 				E7FE09C31B713C70009D090C /* PLKScript.m in Sources */,
 				ED1CE2221B72563A0096585B /* PLKSh.m in Sources */,
 				ED4919591B6EB9520084F9C5 /* linenoise.c in Sources */,

--- a/planck/PLKClojureScriptEngine.m
+++ b/planck/PLKClojureScriptEngine.m
@@ -5,6 +5,7 @@
 #import "PLKBundledOut.h"
 #import "PLKFileReader.h"
 #import "PLKFileWriter.h"
+#import "PLKIO.h"
 
 @interface PLKClojureScriptEngine()
 
@@ -182,7 +183,15 @@
             NSDictionary *result = cljs_shell(args, TSTR(arg_in), TSTR(encoding_in), TSTR(encoding_out), env, TSTR(dir));
             return result;
         };
-
+        
+        self.context[@"PLANCK_IO_FILE"] = ^(JSValue* input) {
+            PLKFile *file = [PLKFile file:[ABYUtils valueOfType:[NSString class] fromJSValue:input]];
+            return file;
+        };
+        
+        self.context[@"PLANCK_IO_FILESEQ"] = ^(PLKFile *f) {
+            return cljs_file_seq(f);
+        };
         
         const BOOL isTty = isatty(fileno(stdin));
         

--- a/planck/PLKIO.h
+++ b/planck/PLKIO.h
@@ -21,3 +21,5 @@
 @interface PLKFile : NSObject<PLKFile>
 
 @end
+
+NSArray *cljs_file_seq(PLKFile *input);

--- a/planck/PLKIO.h
+++ b/planck/PLKIO.h
@@ -1,0 +1,23 @@
+//
+//  PLKIO.h
+//  planck
+//
+//  Created by Benedikt Terhechte on 12/08/15.
+//  Copyright © 2015 FikesFarm. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <JavaScriptCore/JavaScriptCore.h>
+
+@class PLKFile;
+
+@protocol PLKFile <JSExport>
+
++(PLKFile*)file:(NSString*)path;
+- (void) deleteFile;
+
+@end
+
+@interface PLKFile : NSObject<PLKFile>
+
+@end

--- a/planck/PLKIO.m
+++ b/planck/PLKIO.m
@@ -20,6 +20,12 @@
     return aFile;
 }
 
+/* I implemented this to get proper string identification on the repl,
+   but somehow it still just says [object PLKFile] */
+- (NSString*) description {
+    return self.path;
+}
+
 - (void) deleteFile {
     NSFileManager *manager = [NSFileManager defaultManager];
     NSError *error = nil;

--- a/planck/PLKIO.m
+++ b/planck/PLKIO.m
@@ -1,0 +1,36 @@
+//
+//  PLKIO.m
+//  planck
+//
+//  Created by Benedikt Terhechte on 12/08/15.
+//  Copyright © 2015 FikesFarm. All rights reserved.
+//
+
+#import "PLKIO.h"
+
+@interface PLKFile()
+@property (retain) NSString *path;
+@end
+
+@implementation PLKFile
+
++(PLKFile*)file:(NSString*)path {
+    PLKFile *aFile = [[PLKFile alloc] init];
+    aFile.path = path;
+    return aFile;
+}
+
+- (void) deleteFile {
+    NSFileManager *manager = [NSFileManager defaultManager];
+    NSError *error = nil;
+    [manager removeItemAtPath:self.path error:&error];
+    
+    if (error != nil) {
+        // FIXME: Should throw an exception, or return something indicating that there
+        // was an error
+        NSLog(@"Error: %@", error);
+        return;
+    }
+}
+@end
+

--- a/planck/PLKIO.m
+++ b/planck/PLKIO.m
@@ -34,3 +34,46 @@
 }
 @end
 
+NSArray *cljs_file_seq(PLKFile *input) {
+    // Create a local file manager instance
+    NSFileManager *localFileManager=[[NSFileManager alloc] init];
+    
+    BOOL isDirectory = NO;
+    BOOL exists = [localFileManager fileExistsAtPath:input.path isDirectory:&isDirectory];
+    
+    
+    if (!isDirectory || !exists) {
+        NSLog(@"Error: file isn't a directory or doesn't exist");
+        return @[];
+    }
+    
+    // Request the two properties the method uses, name and isDirectory
+    // Ignore hidden files
+    NSURL *inputURL = [NSURL fileURLWithPath:input.path];
+    NSDirectoryEnumerator *dirEnumerator = [localFileManager enumeratorAtURL:inputURL
+                                                  includingPropertiesForKeys:[NSArray arrayWithObjects:NSURLNameKey,
+                                                                              NSURLIsDirectoryKey,nil]
+                                                                     options:NSDirectoryEnumerationSkipsHiddenFiles
+                                                                errorHandler:nil];
+    
+    // An array to store the all the enumerated file names in
+    NSMutableArray *theArray=[NSMutableArray array];
+    
+    // Enumerate the dirEnumerator results, each value is stored in allURLs
+    for (NSURL *theURL in dirEnumerator) {
+        
+        // Retrieve the file name. From NSURLNameKey, cached during the enumeration.
+        NSString *fileName;
+        [theURL getResourceValue:&fileName forKey:NSURLNameKey error:NULL];
+        
+        // Retrieve whether a directory. From NSURLIsDirectoryKey, also
+        // cached during the enumeration.
+        NSNumber *isDirectory;
+        [theURL getResourceValue:&isDirectory forKey:NSURLIsDirectoryKey error:NULL];
+        
+        [theArray addObject: [PLKFile file:theURL.path]];
+    }
+    
+    return theArray.copy;
+}
+


### PR DESCRIPTION
This pull requests implements `file` and `file-seq`.

`file` is wrapped by a new PLKFile class in PLKIO.m/h. This class currently only contains creation and deletion operations but can host all the other file operations from clojure io. Currently, a PLKFile object is printed on the REPL / in the console as `[object PLKFile]`. I've implemented -description in order to instead print the proper path of the file being represented by it, but somehow that didn't do it. I also did some research on how to influence the JS log output of obj-c JSExport objects but couldn't figure out how to do it.

file also currently has a simplified implementation of the multi-arity clojure version.

`file-seq` currently doesn't list hidden files, I'm not sure if that's the clojure default.
