### PR TITLE
Add simple script output of resulting binary location. Added some sim…

### DIFF
--- a/script/build
+++ b/script/build
@@ -6,5 +6,11 @@ script/build
 script/bundle
 cd ..
 
+
 # Xcode
-xcodebuild -project planck.xcodeproj -scheme planck -configuration Release SYMROOT=$(PWD)/build
+BUILD_DIR=build
+CONFIGURATION=Release
+
+xcodebuild -project planck.xcodeproj -scheme planck -configuration $CONFIGURATION SYMROOT=$(PWD)/$BUILD_DIR
+
+echo "Binary located at $(PWD)/$BUILD_DIR/$CONFIGURATION/planck"


### PR DESCRIPTION
This pull request adds a fairly simple addition of `script/build` output of binary location for issue #63. I extracted a couple build parameters for consistency though wasn't sure this was necessary with the scheme.