### PR TITLE
Fails build immediately if ClojureScript build or bundle fail

### DIFF
--- a/planck-cljs/script/build
+++ b/planck-cljs/script/build
@@ -1,2 +1,7 @@
 #!/bin/bash
+
+# Make sure we fail and exit on the command that actually failed.
+set -e
+set -o pipefail
+
 lein run -m clojure.main script/build.clj

--- a/planck-cljs/script/bundle
+++ b/planck-cljs/script/bundle
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Make sure we fail and exit on the command that actually failed.
+set -e
+set -o pipefail
+
 echo '#import <Foundation/Foundation.h>' > PLKBundledOut.m
 echo "" > manifest.m
 cd out

--- a/script/build
+++ b/script/build
@@ -1,9 +1,26 @@
 #!/bin/bash
 
+#----------------------------------------------------
+# Exit if the last command failed, indicating 
+# that there was a build failure
+#----------------------------------------------------
+checkCmdSuccess() {
+    CMD_RESULT=$?
+    if [ $CMD_RESULT != 0 ]; then
+        echo "Build Failed."
+        exit $CMD_RESULT 
+    fi
+}
+
+
 # ClojureScript
 cd planck-cljs
+echo "### Building ClojureScript"
 script/build
+checkCmdSuccess
+echo "### Bundling ClojureScript"
 script/bundle
+checkCmdSuccess
 cd ..
 
 
@@ -11,6 +28,8 @@ cd ..
 BUILD_DIR=build
 CONFIGURATION=Release
 
+echo "### Building Binary"
 xcodebuild -project planck.xcodeproj -scheme planck -configuration $CONFIGURATION SYMROOT=$(PWD)/$BUILD_DIR
+checkCmdSuccess
 
 echo "Binary located at $(PWD)/$BUILD_DIR/$CONFIGURATION/planck"


### PR DESCRIPTION
This pull request is for #62. I went a tiny bit further in echoing some build stage markers in the top level build script and making sure the script always displays "Build Failed" in any of these cases (thinking about CI output). I can pull some of that out if it is too much.