### PR TITLE
Fixes #39, Adds load-file REPL special with integration tests.

### DIFF
--- a/int-test/expected/PLANCK-ERR.txt
+++ b/int-test/expected/PLANCK-ERR.txt
@@ -5,3 +5,4 @@ WARNING: planck.io/spit is deprecated. at line 1
 WARNING: planck.io/spit is deprecated. at line 1 
 WARNING: planck.io/spit is deprecated. at line 1 
 WARNING: planck.io/spit is deprecated. at line 1 
+WARNING: Use of undeclared Var test-load-file.error-in-file/invalid at line 3 

--- a/int-test/expected/PLANCK-OUT.txt
+++ b/int-test/expected/PLANCK-OUT.txt
@@ -51,7 +51,6 @@ space before and after
 Test print to stderr
 nil
 Test main
-5
 Test require REPL special
 nil
 true
@@ -124,6 +123,15 @@ ouch
 
 nil
 whoah
+
+nil
+Test load-file REPL special
+nil
+true
+Test load-file REPL bad filename
+Could not load file int-test/src/test_load_file/nofile.cljs
+	 planck$repl$process_load_file (planck/repl.cljs:160:3)
+	 planck$repl$read_eval_print (planck/repl.cljs:318:26)
 
 nil
 Spit / slurp

--- a/int-test/expected/PLANCK-OUT.txt
+++ b/int-test/expected/PLANCK-OUT.txt
@@ -51,6 +51,7 @@ space before and after
 Test print to stderr
 nil
 Test main
+5
 Test require REPL special
 nil
 true
@@ -128,11 +129,18 @@ nil
 Test load-file REPL special
 nil
 true
+Test doc support for load-file REPL special
+-------------------------
+load-file
+([filename])
+REPL Special Function
+  Loads a file
+nil
 Test load-file REPL bad filename
 Could not load file int-test/src/test_load_file/nofile.cljs
-	 planck$repl$process_load_file (planck/repl.cljs:160:3)
-	 planck$repl$read_eval_print (planck/repl.cljs:318:26)
-
+nil
+Test load-file REPL error in file
+undefined is not an object (evaluating 'test_load_file.error_in_file.invalid.call')
 nil
 Spit / slurp
 #'cljs.user/test-file

--- a/int-test/script/gen-actual
+++ b/int-test/script/gen-actual
@@ -133,6 +133,17 @@ $PLANCK <<REPL_INPUT
 (pst e)
 REPL_INPUT
 
+echo "Test load-file REPL special"
+$PLANCK -s $SRC <<REPL_INPUT
+(load-file "int-test/src/test_load_file/core.cljs")
+test-load-file.core/success
+REPL_INPUT
+
+echo "Test load-file REPL bad filename"
+$PLANCK -s $SRC <<REPL_INPUT
+(load-file "int-test/src/test_load_file/nofile.cljs")
+REPL_INPUT
+
 echo "Spit / slurp"
 $PLANCK <<REPL_INPUT
 (def test-file "/tmp/PLANCK_TEST.txt")

--- a/int-test/script/gen-actual
+++ b/int-test/script/gen-actual
@@ -139,9 +139,19 @@ $PLANCK -s $SRC <<REPL_INPUT
 test-load-file.core/success
 REPL_INPUT
 
+echo "Test doc support for load-file REPL special"
+$PLANCK -s $SRC <<REPL_INPUT
+(doc load-file)
+REPL_INPUT
+
 echo "Test load-file REPL bad filename"
 $PLANCK -s $SRC <<REPL_INPUT
 (load-file "int-test/src/test_load_file/nofile.cljs")
+REPL_INPUT
+
+echo "Test load-file REPL error in file"
+$PLANCK -s $SRC <<REPL_INPUT
+(load-file "int-test/src/test_load_file/error_in_file.cljs")
 REPL_INPUT
 
 echo "Spit / slurp"

--- a/int-test/src/test_load_file/core.cljs
+++ b/int-test/src/test_load_file/core.cljs
@@ -1,0 +1,3 @@
+(ns test-load-file.core)
+
+(def success true)

--- a/int-test/src/test_load_file/error_in_file.cljs
+++ b/int-test/src/test_load_file/error_in_file.cljs
@@ -1,0 +1,5 @@
+(ns test-load-file.error-in-file)
+
+(invalid)
+
+(def success true)

--- a/planck-cljs/src/planck/repl.cljs
+++ b/planck-cljs/src/planck/repl.cljs
@@ -55,7 +55,7 @@
 (defn ns-form? [form]
   (and (seq? form) (= 'ns (first form))))
 
-(def repl-specials '#{in-ns require require-macros doc pst})
+(def repl-specials '#{in-ns require require-macros doc pst load-file})
 
 (defn repl-special? [form]
   (and (seq? form) (repl-specials (first form))))
@@ -70,7 +70,9 @@
     doc            {:arglists ([name])
                     :doc      "Prints documentation for a var or special form given its name"}
     pst            {:arglists ([] [e])
-                    :doc      "Prints a stack trace of the exception.\n  If none supplied, uses the root cause of the most recent repl exception (*e)"}})
+                    :doc      "Prints a stack trace of the exception.\n  If none supplied, uses the root cause of the most recent repl exception (*e)"}
+    load-file      {:arglists  ([file])
+                    :doc      "Loads a file"}})
 
 (defn- repl-special-doc [name-symbol]
   (assoc (repl-special-doc-map name-symbol)
@@ -135,7 +137,28 @@
             (reset! current-ns restore-ns))
           (when e
             (print-error e false))
-          (cb))))
+          )))
+    (catch :default e
+      (print-error e))))
+
+(defn- process-load-file
+  "Given a filename, sequentially read and evaluate
+   the set of forms contained in the file"
+  [filename]
+  (try
+    (let [file-contents (or (js/PLANCK_READ_FILE filename)
+                           (throw (js/Error. (str "Could not load file " filename))))]
+      (cljs/eval-str
+        st
+       file-contents
+       filename
+        {:ns      @current-ns
+         :context :expr
+         :verbose (:verbose @app-env)}
+        (fn [{e :error}]
+          (when e
+            (print-error e false))
+          )))
     (catch :default e
       (print-error e))))
 
@@ -300,7 +323,9 @@
                          {:ns      @current-ns
                           :context :expr}
                          print-error)
-                       (catch js/Error e (prn :caught e)))))
+                       (catch js/Error e (prn :caught e))))
+            load-file (let [filename (second expression-form)]
+                        (process-load-file filename)))
           (prn nil))
         (try
           (cljs/eval-str


### PR DESCRIPTION
This is my first ClojureScript contribution to the project, so definitely a newbie and code review / feedback expected. I believe this has at least introduced basic load-file support.

I tried following the suggestions left in #39 but couldn't get it to work, so went the separate fn route inspired by what is happening with require. I couldn't get `planck.io/slurp` to work directly so went with what I saw under the hood and got that to work. Also, made a stab at introducing some integration tests for this, so hopefully followed the convention.

Is this on track? Any suggestions for refactoring / testing / anything else?