### PR TITLE
Properly exit with correct code when (exit 0) called.

### DIFF
--- a/planck-cljs/test/planck/core_test.cljs
+++ b/planck-cljs/test/planck/core_test.cljs
@@ -2,6 +2,8 @@
   (:require [cljs.test :refer-macros [deftest testing is]]
             [planck.core]))
 
-(deftest a-test
-  (testing "Stub passing test"
-    (is (= 0 0))))
+(deftest exit-throws
+  (testing "exit throws EXIT exception"
+    (is (thrown-with-msg? js/Error #"PLANCK_EXIT" (planck.core/exit 112))))
+  (testing "exit sets global exit code"
+    (is (= 112 (js/PLANCK_GET_EXIT_VALUE)))))

--- a/planck-cljs/test/planck/repl_test.cljs
+++ b/planck-cljs/test/planck/repl_test.cljs
@@ -14,3 +14,57 @@
     (is (= [2 0] (js->clj (planck.repl/get-highlight-coords 1 "]" ["[" "[]"]))))
     (is (= [0 1] (js->clj (planck.repl/get-highlight-coords 2 "#{}" []))))
     (is (= [0 0] (js->clj (planck.repl/get-highlight-coords 4 "[\"[\"]" []))))))
+
+(deftest handle-error-non-exit-exception-non-exit-context
+  (js/PLANCK_SET_EXIT_VALUE -1)
+  (let [result (planck.repl/handle-error (js/Error. "Original Error") false false)]
+    (testing "Non-exit exception outside of exit context returns original error"
+      (is (= "Original Error" (.-message result))))
+    (testing "Non-exit exception outside of exit context preserves existing exit code"
+      (is (= -1 (js/PLANCK_GET_EXIT_VALUE)))))
+  (js/PLANCK_SET_EXIT_VALUE 0))
+
+(deftest handle-error-exit-exception-non-exit-context
+  (js/PLANCK_SET_EXIT_VALUE 47)
+  (let [result (planck.repl/handle-error (js/Error. "PLANCK_EXIT") false false)]
+    (testing "Exit exception outside of exit context returns original error"
+      (is (= "PLANCK_EXIT" (.-message result))))
+    (testing "Exit exception outside of exit context preserves existing exit code"
+      (is (= 47 (js/PLANCK_GET_EXIT_VALUE)))))
+  (js/PLANCK_SET_EXIT_VALUE 0))
+
+(deftest handle-error-non-exit-exception-in-exit-context
+  (js/PLANCK_SET_EXIT_VALUE -1)
+  (let [result (planck.repl/handle-error (js/Error. "Original Error") false true)]
+    (testing "Non-exit exception in exit context returns nothing"
+      (is (= nil result)))
+    (testing "Non-exit exception in exit context sets a default exit code"
+      (is (= 1 (js/PLANCK_GET_EXIT_VALUE)))))
+  (js/PLANCK_SET_EXIT_VALUE 0))
+
+(deftest handle-error-exit-exception-in-exit-context
+  (js/PLANCK_SET_EXIT_VALUE 32)
+  (let [result (planck.repl/handle-error (js/Error. "PLANCK_EXIT") false true)]
+    (testing "Exit exception in exit context returns exit error"
+      (is (= "PLANCK_EXIT" (.-message result))))
+    (testing "Exit exception in exit context preserves existing exit code"
+      (is (= 32 (js/PLANCK_GET_EXIT_VALUE)))))
+  (js/PLANCK_SET_EXIT_VALUE 0))
+
+(deftest read-eval-print-exception-in-exit-context
+  (js/PLANCK_SET_EXIT_VALUE 0)
+  (let [result (planck.repl/read-eval-print "(throw (js/Error. \"bye-bye\"))" false false true)]
+    (testing "default exception return code as a side-effect"
+      (is (= 1 (js/PLANCK_GET_EXIT_VALUE))))
+    (testing "returns nothing"
+      (is (= nil result))))
+  (js/PLANCK_SET_EXIT_VALUE 0))
+
+(deftest read-eval-print-exception-outside-exit-context
+  (js/PLANCK_SET_EXIT_VALUE 0)
+  (let [result (planck.repl/read-eval-print "(throw (js/Error. \"bye-bye\"))" false false false)]
+    (testing "doesn't touch exit value"
+      (is (= 0 (js/PLANCK_GET_EXIT_VALUE))))
+    (testing "returns error"
+      (is (not (= nil result)))))
+  (js/PLANCK_SET_EXIT_VALUE 0))

--- a/planck/PLKClojureScriptEngine.h
+++ b/planck/PLKClojureScriptEngine.h
@@ -1,5 +1,10 @@
 #import <Foundation/Foundation.h>
 
+// Similar to EXIT_SUCCESS, but use this to
+// indicate an internal success that shouldn't
+// terminate a REPL session
+#define	PLANK_EXIT_SUCCESS_NONTERMINATE	-257
+
 @interface PLKClojureScriptEngine : NSObject
 
 -(void)startInitializationWithSrcPaths:(NSArray*)srcPaths outPath:(NSString*)outPath verbose:(BOOL)verbose boundArgs:(NSArray*)boundArgs;

--- a/planck/PLKClojureScriptEngine.m
+++ b/planck/PLKClojureScriptEngine.m
@@ -512,6 +512,15 @@ NSString* NSStringFromJSValueRef(JSContextRef ctx, JSValueRef jsValueRef)
         
         [ABYUtils installGlobalFunctionWithBlock:
          ^JSValueRef(JSContextRef ctx, size_t argc, const JSValueRef argv[]) {
+            return JSValueMakeNumber(ctx, weakSelf.exitValue);
+        }
+                                            name:@"PLANCK_GET_EXIT_VALUE"
+                                            argList:@""
+                                            inContext:self.context];
+
+        
+        [ABYUtils installGlobalFunctionWithBlock:
+         ^JSValueRef(JSContextRef ctx, size_t argc, const JSValueRef argv[]) {
              
              if (argc == 1 && JSValueGetType (ctx, argv[0]) == kJSTypeString) {
                  
@@ -525,6 +534,7 @@ NSString* NSStringFromJSValueRef(JSContextRef ctx, JSValueRef jsValueRef)
                                             name:@"PLANCK_FILE_READER_OPEN"
                                          argList:@"path"
                                        inContext:self.context];
+
         
         [ABYUtils installGlobalFunctionWithBlock:
          ^JSValueRef(JSContextRef ctx, size_t argc, const JSValueRef argv[]) {
@@ -779,7 +789,12 @@ NSString* NSStringFromJSValueRef(JSContextRef ctx, JSValueRef jsValueRef)
 -(int)executeClojureScript:(NSString*)source expression:(BOOL)expression printNilExpression:(BOOL)printNilExpression inExitContext:(BOOL)inExitContext
 {
     [self blockUntilEngineReady];
-    self.exitValue = EXIT_SUCCESS;
+    if (!inExitContext) {
+        // Default return value will indicate non-terminating successful exit
+        self.exitValue = PLANK_EXIT_SUCCESS_NONTERMINATE;
+    } else {
+        self.exitValue = EXIT_SUCCESS;
+    }
     
     JSValueRef  arguments[4];
     JSValueRef result;
@@ -789,7 +804,7 @@ NSString* NSStringFromJSValueRef(JSContextRef ctx, JSValueRef jsValueRef)
     arguments[2] = JSValueMakeBoolean(self.context, printNilExpression);
     arguments[3] = JSValueMakeBoolean(self.context, inExitContext);
     result = JSObjectCallAsFunction(self.context, [self getFunction:@"read-eval-print"], JSContextGetGlobalObject(self.context), num_arguments, arguments, NULL);
-    
+
     return self.exitValue;
 }
 

--- a/planck/PLKRepl.m
+++ b/planck/PLKRepl.m
@@ -243,7 +243,7 @@ void highlightCancel() {
                                                                expression:YES
                                                        printNilExpression:YES
                                                             inExitContext:NO];
-                if (exitValue != EXIT_SUCCESS) {
+                if (exitValue != PLANK_EXIT_SUCCESS_NONTERMINATE) {
                     break;
                 }
             
@@ -272,6 +272,11 @@ void highlightCancel() {
         
     }
     
+    // PLANK_EXIT_SUCCESS_NONTERMINATE is for internal use only, so to the rest of the world
+    // it is a standard successful exit
+    if (exitValue == PLANK_EXIT_SUCCESS_NONTERMINATE) {
+        exitValue = EXIT_SUCCESS;
+    }
     return exitValue;
 }
 

--- a/script/unit-test
+++ b/script/unit-test
@@ -5,7 +5,7 @@
             [planck.test-runner]
             [planck.core :refer [exit]]))
 
-;; Note, to run unit tests, scrupt/build must be run
+;; Note, to run unit tests, script/build must be run
 ;; to pre-compile them as we can't yet run cljs.test in
 ;; bootstrapped mode.
 


### PR DESCRIPTION
This change uses an internal exit code (technically invalid, but possible to call) to indicate to the
REPL when an error has occurred, allowing the default of 0 to be used as a valid exit code.

Closes #90