### PR TITLE
Adds support for setTimeout

### DIFF
--- a/planck-cljs/test/planck/core_test.cljs
+++ b/planck-cljs/test/planck/core_test.cljs
@@ -7,3 +7,15 @@
     (is (thrown-with-msg? js/Error #"PLANCK_EXIT" (planck.core/exit 112))))
   (testing "exit sets global exit code"
     (is (= 112 (js/PLANCK_GET_EXIT_VALUE)))))
+
+(deftest setTimeout-can-be-used
+  "This test is intentionally a bit naieve since async macros wouldn't work at time of writing"
+  (testing "setTimeout actually gets called and does something"
+    (let [now #(.getTime (js/Date.))
+          t (now)
+          test-state (atom :foo)]
+      (js/setTimeout (fn []
+                       (reset! test-state :bar))
+                     100)
+      (while (< (now) (+ t 500)))
+      (is (= :bar @test-state)))))


### PR DESCRIPTION
Adds support for setTimeout via customizing timer set up from Ambly to operate on the right queue and flush output.

Closes #81