### PR TITLE
fix cljs.tools.reader dependency issue

### DIFF
--- a/planck-cljs/project.clj
+++ b/planck-cljs/project.clj
@@ -2,6 +2,7 @@
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/clojurescript "1.7.122"]
                  [tailrecursion/cljson "1.0.7"]
+                 [org.clojure/tools.reader "0.10.0-alpha3"]
                  [com.cognitect/transit-clj "0.8.275"]
                  [com.cognitect/transit-cljs "0.8.220"]]
   :clean-targets ["out" "target"])


### PR DESCRIPTION
when following the development instructions, i was running into this issue when running the build script.

``` 
Caused by: clojure.lang.ExceptionInfo: No such namespace: cljs.tools.reader, could not locate cljs/tools/reader.cljs, cljs/tools/reader.cljc, or Closure namespace "cljs.tools.reader" {:tag :cljs/analysis-error}
	at clojure.core$ex_info.invoke(core.clj:4593)
	at cljs.analyzer$error.invoke(analyzer.cljc:535)
	at cljs.analyzer$error.invoke(analyzer.cljc:533)
	at cljs.analyzer$analyze_deps.invoke(analyzer.cljc:1637)
	at cljs.analyzer$ns_side_effects.invoke(analyzer.cljc:2470)
	at cljs.analyzer$analyze_STAR_$fn__1897.invoke(analyzer.cljc:2551)
	at clojure.lang.PersistentVector.reduce(PersistentVector.java:333)
	at clojure.core$reduce.invoke(core.clj:6518)
	at cljs.analyzer$analyze_STAR_.invoke(analyzer.cljc:2551)
	at cljs.analyzer$analyze.invoke(analyzer.cljc:2566)
	at cljs.compiler$compile_file_STAR_$fn__3073.invoke(compiler.cljc:1125)
	at cljs.compiler$with_core_cljs.invoke(compiler.cljc:1053)
	at cljs.compiler$compile_file_STAR_.invoke(compiler.cljc:1076)
	at cljs.compiler$compile_file$fn__3114.invoke(compiler.cljc:1237)
	... 59 more
```

explicitly adding the tools reader dependency allows the build to work. 