### PR TITLE
mention namespace in help

### DIFF
--- a/int-test/script/int-tests
+++ b/int-test/script/int-tests
@@ -55,8 +55,8 @@ Usage:  planck [init-opt*] [main-opt] [args]
   operation:
 
     - Enters the cljs.user namespace
-    - Binds *command-line-args* to a seq of strings containing command line
-      args that appear after any main option
+    - Binds planck.core/*command-line-args* to a seq of strings containing
+      command line args that appear after any main option
     - Runs all init options in order
     - Calls a -main function or runs a repl or script if requested
 

--- a/planck/PLKCommandLine.m
+++ b/planck/PLKCommandLine.m
@@ -260,8 +260,8 @@
             printf("  operation:\n");
             printf("\n");
             printf("    - Enters the cljs.user namespace\n");
-            printf("    - Binds planck.core/*command-line-args* to a seq of strings containing command line\n");
-            printf("      args that appear after any main option\n");
+            printf("    - Binds planck.core/*command-line-args* to a seq of strings containing\n");
+            printf("       command line args that appear after any main option\n");
             printf("    - Runs all init options in order\n");
             printf("    - Calls a -main function or runs a repl or script if requested\n");
             printf("\n");

--- a/planck/PLKCommandLine.m
+++ b/planck/PLKCommandLine.m
@@ -261,7 +261,7 @@
             printf("\n");
             printf("    - Enters the cljs.user namespace\n");
             printf("    - Binds planck.core/*command-line-args* to a seq of strings containing\n");
-            printf("       command line args that appear after any main option\n");
+            printf("      command line args that appear after any main option\n");
             printf("    - Runs all init options in order\n");
             printf("    - Calls a -main function or runs a repl or script if requested\n");
             printf("\n");

--- a/planck/PLKCommandLine.m
+++ b/planck/PLKCommandLine.m
@@ -260,7 +260,7 @@
             printf("  operation:\n");
             printf("\n");
             printf("    - Enters the cljs.user namespace\n");
-            printf("    - Binds *command-line-args* to a seq of strings containing command line\n");
+            printf("    - Binds planck.core/*command-line-args* to a seq of strings containing command line\n");
             printf("      args that appear after any main option\n");
             printf("    - Runs all init options in order\n");
             printf("    - Calls a -main function or runs a repl or script if requested\n");


### PR DESCRIPTION
I was playing around with command line parameters, and it took me a while to figure out that the relevant variable was defined in the `planck.core` namespace. I don't see it documented anywhere except for an issue mentioning that it would be nice if it was defined in every namespace automatically.

Hence this tiny pull request :-)

Btw I needed also to do a `(:require [planck.core])`, but I guess that's actually how it's supposed to work? I have found that I can just refer to stuff with their fully qualified namespace without requireing the namespace when using the java cljs compiler. 