### PR TITLE
Add a with-open macro, fixes #57

### DIFF
--- a/planck-cljs/script/bundle
+++ b/planck-cljs/script/bundle
@@ -4,7 +4,7 @@
 set -e
 set -o pipefail
 
-cp src/planck/repl.clj out/planck
+cp src/planck/{repl,core}.clj out/planck
 
 echo '#import <Foundation/Foundation.h>' > PLKBundledOut.m
 echo '#import "zlib.h"' >> PLKBundledOut.m

--- a/planck-cljs/src/planck/core.clj
+++ b/planck-cljs/src/planck/core.clj
@@ -1,0 +1,24 @@
+(ns planck.core)
+
+(defmacro with-open
+  "bindings => [name IClosable ...]
+
+  Evaluates body in a try expression with names bound to the values
+  of the inits, and a finally clause that calls (-close name) on each
+  name in reverse order."
+  [bindings & body]
+  ;; when http://dev.clojure.org/jira/browse/CLJS-1551 lands,
+  ;; replace with assert-args
+  (when-not (vector? bindings)
+    (throw (js/Error. "with-open requires a vector for its bindings")))
+  (when-not (even? (count bindings))
+    (throw (js/Error. "with-open requires an even number of forms in binding vector")))
+  (cond
+    (= (count bindings) 0) `(do ~@body)
+    (symbol? (bindings 0)) `(let ~(subvec bindings 0 2)
+                              (try
+                                (with-open ~(subvec bindings 2) ~@body)
+                                (finally
+                                  (-close ~(bindings 0)))))
+    :else (throw (js/Error.
+                  "with-open only allows symbols in bindings"))))


### PR DESCRIPTION
I'm way out of my comfort zone here, so please bear with me.

I've added `clojure.core/with-open` and changed it to using `-close` and to throw a `js/Error`

It is not tested, since I'm not quite familiar with how to get the macros loaded in planck.

If you could provide me with a recipe on how to load this into the REPL, and an example use-case, I'd be more than happy to continue with this if you think it's on the right path.