### PR TITLE
Fixes #221

### DIFF
--- a/int-test/expected/PLANCK-OUT.txt
+++ b/int-test/expected/PLANCK-OUT.txt
@@ -200,7 +200,7 @@ nil
 #'foo.bar/macro-crazy
 nil
 (cljs.core/ffirst cljs.core/nfirst foo.bar/xfirst)
-(cljs.core/defmacro cljs.core/find-macros-ns cljs.core/macroexpand cljs.core/macroexpand-1 foo.bar/macro-crazy)
+(cljs.core/defmacro cljs.core/find-macros-ns cljs.core/macroexpand cljs.core/macroexpand-1 cljs.reader/dispatch-macros cljs.reader/macro-terminating? cljs.reader/macros foo.bar/macro-crazy)
 (cljs.core/macroexpand cljs.core/macroexpand-1)
 Test dir
 nil

--- a/int-test/script/int-tests
+++ b/int-test/script/int-tests
@@ -1,7 +1,7 @@
 #!build/Release/planck -k int-test/cache
 (ns planck.int-tests
-  (:require [planck.core :refer [exit]]
-            [planck.shell :refer [sh *sh-dir*]]))
+  (:require [planck.core]
+            [planck.shell]]))
 
 (def planck-version "1.10")
 
@@ -10,7 +10,7 @@
 ;; namespaces, etc.
 ;;
 ;; For now, all you ned to do to cause the tests
-;; to fail is call `(exit 1)`.
+;; to fail is call `(planck.core/exit 1)`.
 
 (def planck-exe "build/Release/planck")
 
@@ -21,7 +21,7 @@
     (prn expected)
     (println "Actual:")
     (prn (:out shell-output))
-    (exit 1)))
+    (planck.core/exit 1)))
 
 (check-output
   (str
@@ -66,7 +66,7 @@ Usage:  planck [init-opt*] [main-opt] [arg*]
   Paths may be absolute or relative in the filesystem.
 
   A comprehensive User Guide for Planck can be found at http://planck-repl.org\n\n")
-  (sh planck-exe "-h"))
+  (planck.shell/sh planck-exe "-h"))
 
 (defn ensure-output [expected quoted-commands]
   (check-output
@@ -101,14 +101,14 @@ Usage:  planck [init-opt*] [main-opt] [arg*]
    '(cl-format nil "~:d" 123456789)])
 
 ;; Ensure we don't get a degenerate env
-(when (= "true\n" (:out (sh planck-exe "-e" "(require '[planck.shell :refer [sh]])" "-e" "(empty? (:out (sh \"env\")))")))
+(when (= "true\n" (:out (planck.shell/sh planck-exe "-e" "(require '[planck.shell :refer [sh]])" "-e" "(empty? (:out (sh \"env\")))")))
   (println "empty env")
-  (exit 1))
+  (planck.core/exit 1))
 
 ;; Ensure env workd
 (ensure-output (into (sorted-map) {:err "", :exit 0, :out "ABC=123\n"})
   ['(require '[planck.shell :refer [sh]])
-   '(into (sorted-map) (sh "env" :env {"ABC" "123"}))])
+   '(into (sorted-map) (planck.shell/sh "env" :env {"ABC" "123"}))])
 
 ;; Test import REPL special
 (ensure-output "http"
@@ -128,18 +128,18 @@ Usage:  planck [init-opt*] [main-opt] [arg*]
    '(join (range 10))])
 
 ;; Ensure slurp throws an error for failed read
-(sh "rm" "-f" "/tmp/no-such-animal")
+(planck.shell/sh "rm" "-f" "/tmp/no-such-animal")
 (ensure-output "SONIC BOOOOOOOOM!"
   ['(require '[planck.core :refer [slurp]])
    '(try (slurp "/tmp/no-such-animal") (catch js/Error e "SONIC BOOOOOOOOM!"))])
 
 ;; Ensure spit throws an error for failed write
-(sh "touch" "/tmp/readonly")
-(sh "chmod" "444" "/tmp/readonly")
+(planck.shell/sh "touch" "/tmp/readonly")
+(planck.shell/sh "chmod" "444" "/tmp/readonly")
 (ensure-output "SONIC BOOOOOOOOM!"
   ['(require '[planck.core :refer [spit]])
    '(try (spit "/tmp/readonly" "foo") (catch js/Error e "SONIC BOOOOOOOOM!"))])
-(sh "rm" "-f" "/tmp/readonly")
+(planck.shell/sh "rm" "-f" "/tmp/readonly")
 
 ;; Check that 0 evaluates to true
 (ensure-output :truthy

--- a/planck-cljs/script/build.clj
+++ b/planck-cljs/script/build.clj
@@ -60,8 +60,7 @@
 
 (extract-analysis-cache "out/cognitect/transit.cljs.cache.edn" "out/cognitect/transit.cljs.cache.json")
 
-;; Uncomment to be able to work with 'planck.repl in Planck
-#_(extract-analysis-cache "out/planck/repl.cljs.cache.edn" "out/planck/repl.cljs.cache.json")
+(extract-analysis-cache "out/planck/repl.cljs.cache.edn" "out/planck/repl.cljs.cache.json")
 (extract-analysis-cache "out/planck/core.cljs.cache.edn" "out/planck/core.cljs.cache.json")
 (extract-analysis-cache "out/planck/io.cljs.cache.edn" "out/planck/io.cljs.cache.json")
 (extract-analysis-cache "out/planck/shell.cljs.cache.edn" "out/planck/shell.cljs.cache.json")

--- a/planck-cljs/src/planck/repl.cljs
+++ b/planck-cljs/src/planck/repl.cljs
@@ -445,7 +445,7 @@
                                   (read-build-affecting-options build-affecting-options))]
     [cljs-ver build-affecting-options]))
 
-(defn is-macros?
+(defn- is-macros?
   [cache]
   (s/ends-with? (str (:name cache)) "$macros"))
 

--- a/script/unit-test
+++ b/script/unit-test
@@ -2,7 +2,7 @@
 (ns planck.unit-test
   (:require [cljs.test]
             [planck.test-runner]
-            [planck.core :refer [exit]]))
+            [planck.core]))
 
 ;; Note, to run unit tests, script/build must be run
 ;; to pre-compile them as we can't yet run cljs.test in
@@ -10,6 +10,6 @@
 
 (defmethod cljs.test/report [:cljs.test/default :end-run-tests] [m]
   (when-not (cljs.test/successful? m)
-    (exit 1)))
+    (planck.core/exit 1)))
 
 (planck.test-runner/run-all-tests)


### PR DESCRIPTION
Root cause for IDeref error is not identified

- use fq package name to refer to exit removes the
  IDeref error
- Remove comment which is no longer true

Please do test this properly as I might have overlooked something.