### PR TITLE
Implement an http client

### DIFF
--- a/planck-cljs/script/build.clj
+++ b/planck-cljs/script/build.clj
@@ -75,6 +75,7 @@
 (extract-analysis-cache "out/planck/core.cljs.cache.edn" "out/planck/core.cljs.cache.json")
 (extract-analysis-cache "out/planck/io.cljs.cache.edn" "out/planck/io.cljs.cache.json")
 (extract-analysis-cache "out/planck/shell.cljs.cache.edn" "out/planck/shell.cljs.cache.json")
+(extract-analysis-cache "out/planck/http.cljs.cache.edn" "out/planck/http.cljs.cache.json")
 (extract-analysis-cache "out/planck/from/io/aviso/ansi.cljs.cache.edn" "out/planck/from/io/aviso/ansi.cljs.cache.json")
 
 (extract-analysis-cache "out/tailrecursion/cljson.cljs.cache.edn" "out/tailrecursion/cljson.cljs.cache.json")
@@ -86,6 +87,7 @@
 (extract-analysis-cache "out/planck/io_test.cljs.cache.edn" "out/planck/io_test.cljs.cache.json")
 (extract-analysis-cache "out/planck/shell_test.cljs.cache.edn" "out/planck/shell_test.cljs.cache.json")
 (extract-analysis-cache "out/planck/repl_test.cljs.cache.edn" "out/planck/repl_test.cljs.cache.json")
+(extract-analysis-cache "out/planck/http_test.cljs.cache.edn" "out/planck/http_test.cljs.cache.json")
 
 (println "Done building")
 (System/exit 0)

--- a/planck-cljs/src/planck/core.cljs
+++ b/planck-cljs/src/planck/core.cljs
@@ -175,7 +175,7 @@
   "Opens a reader on f and reads all its contents, returning a string.
   See planck.io/reader for a complete list of supported arguments."
   [f & opts]
-  (let [r  (apply *reader-fn* f opts)
+  (let [r (apply *reader-fn* f opts)
         sb (StringBuffer.)]
     (try
       (loop [s (-read r)]

--- a/planck-cljs/src/planck/http.cljs
+++ b/planck-cljs/src/planck/http.cljs
@@ -1,0 +1,223 @@
+(ns planck.http
+    (:refer-clojure :exclude [get])
+    (:require
+     [planck.core]
+     [planck.io]
+     [clojure.string :as string]))
+
+
+(def content-types {:json            "application/json"
+                    :xml             "application/xml"
+                    :form-urlencoded "application/x-www-form-urlencoded"})
+
+(def default-timeout 5)
+
+(def boundary-constant "---------------planck-rocks-")
+
+(def content-disposition "\nContent-Disposition: form-data; name=\"")
+
+(defn- encode-val [k v]
+  (str (js/encodeURIComponent (name k)) "=" (js/encodeURIComponent (str v))))
+
+(defn- encode-vals [k vs]
+  (->>
+    vs
+    (map #(encode-val k %))
+    (string/join "&")))
+
+(defn- encode-param [[k v]]
+  (if (coll? v)
+    (encode-vals k v)
+    (encode-val k v)))
+
+(defn generate-query-string [params]
+  (->>
+    params
+    (map encode-param)
+    (string/join "&")))
+
+(defn- maybe-add-header [request key header-key]
+  (when-let [val (key request)]
+    (let [header-value (if (keyword? val)
+                         (val content-types)
+                         val)]
+      (merge {header-key header-value} (:headers request)))))
+
+(defn wrap-content-type
+  "Set the appropriate Content Type header."
+  [client]
+  (fn [request]
+    (if-let [headers (maybe-add-header request :content-type "Content-Type")]
+      (-> request
+          (dissoc :content-type)
+          (assoc :headers headers)
+          client)
+      (client request))))
+
+(defn wrap-accepts
+  "Set the appropriate Accept header."
+  [client]
+  (fn [request]
+    (if-let [headers (maybe-add-header request :accept "Accept")]
+      (-> request
+          (dissoc :accept)
+          (assoc :headers headers)
+          client)
+      (client request))))
+
+(defn wrap-debug
+  "adds the request to the response if :debug is present"
+  [client]
+  (fn [request]
+    (if-let [debug (:debug request)]
+      (let [req (dissoc request :debug)]
+        (assoc (client req) :request req))
+      (client request))))
+
+(defn wrap-add-content-length
+  "Adds content-length if :body is present "
+  [client]
+  (fn [request]
+    (if-let [body (:body request)]
+      (let [headers (merge {"Content-length" (count body)} (:headers request))]
+        (-> request
+            (assoc :headers headers)
+            client))
+      (client request))))
+
+(defn wrap-form-params
+  "Adds form-params and content-type"
+  [client]
+  (fn [request]
+    (if-let [form-params (:form-params request)]
+      (-> request
+          (dissoc :form-params)
+          (assoc :content-type :form-urlencoded)
+          (assoc :body (generate-query-string form-params))
+          client)
+      (client request))))
+
+(defn wrap-add-headers
+  "Adds headers to the request if they're not present"
+  [client]
+  (fn [request]
+    (client (assoc request :headers (or (:headers request) {})))))
+
+(defn wrap-add-timeout
+  "Adds default timeout if :timeout is not present"
+  [client timeout]
+  (fn [request]
+    (client (assoc request :timeout (or (:timeout request) timeout)))))
+
+(defn generate-form-data [params]
+  (conj (mapv (fn [[k v]]
+                (if (coll? v)
+                  (str content-disposition  k "\"; filename=\"" (second v) "\"\n"
+                       "Content-Type: application/octet-stream\n\n"
+                       (first v))
+                  (str content-disposition k "\"\n\n" v ))) params) "--\n"))
+
+(defn generate-multipart-body [boundary body-parts]
+  (->> body-parts
+       (map str (repeat boundary))
+       (interpose "\n")
+       (apply str)))
+
+(defn boundary [c]
+  (apply str (cons c (take 10 (repeatedly #(int (rand 10)))))))
+
+(defn wrap-multipart-params [client]
+  (fn [{:keys [multipart-params] :as request}]
+    (if multipart-params
+      (let [b (boundary boundary-constant)
+            body (generate-multipart-body b (generate-form-data multipart-params))]
+        (client (-> request
+                    (dissoc :multipart-params)
+                    (assoc :content-type (str "multipart/form-data; boundary=" b))
+                    (assoc :body body))))
+      (client request))))
+
+(defn wrap-throw-on-error [client]
+  (fn [request]
+    (let [response (client request)]
+      (if-let [error (:error response)]
+        (throw (js/Error. error))
+        response))))
+
+(defn wrap-add-method [client method]
+  (fn [request]
+    (client (assoc request :method (string/upper-case (name method)))))) 
+
+(defn wrap-to-from-js [client]
+  (fn [request]
+    (-> request
+        clj->js
+        client
+        (js->clj :keywordize-keys true))))
+
+(defn- do-request [client]
+  (fn [opts]
+    (client opts)))
+
+(defn request [client method url opts]
+  ((-> client
+       do-request
+       wrap-to-from-js
+       wrap-throw-on-error
+       wrap-debug
+       wrap-accepts
+       wrap-content-type
+       wrap-add-content-length
+       wrap-form-params
+       wrap-multipart-params
+       (wrap-add-timeout default-timeout)
+       wrap-add-headers
+       (wrap-add-method method)) (assoc opts :url url)))
+
+(defn get
+  "Performs a GET request. It takes an URL and an optional map of options.
+  These include:
+  :timeout, number, default 5 seconds
+  :debug, boolean, assoc the request on to the response
+  :accepts, keyword or string. Valid keywords are :json or :xml
+  :content-type, keyword or string Valid keywords are :json or :xml
+  :headers, map, a map containing headers"
+  ([url] (get url {}))
+  ([url opts] (request js/PLANCK_REQUEST :get url opts)))
+
+(defn post
+  "Performs a POST requeest. It takes an URL and an optional map of options
+  These options include the options for get in addition to:
+  :form-params, a map, will become the body of the request, urlencoded
+  :multipart-params, a list of tuples, used for file-upload
+                     {:multipart-params [[\"name\" \"value\"]
+                                         [\"name\" \"content\" \"filename\"]"
+  ([url] (post url {}))
+  ([url opts] (request js/PLANCK_REQUEST :post url opts)))
+
+(extend-protocol planck.io/IOFactory
+  js/goog.Uri
+  (make-reader [url opts]
+    (let [content (atom (:body (get url opts)))]
+      (letfn [(read [] (let [return @content]
+                         (reset! content nil)
+                         return))]
+        (planck.core/Reader.
+         read
+         (fn [])))))
+  (make-writer [url opts]
+    (planck.core/Writer.
+     (fn [s]
+       (post url {:multipart-params [[(or (:param-name opts) "file")
+                                      [s (or (:filename opts) "file.pnk")]]]})
+       nil)
+     (fn [])
+     (fn []))))
+
+(extend-protocol planck.io/Coercions
+  js/goog.Uri
+  (as-url [u] u)
+  (as-file [u]
+    (if (= "file" (.getScheme u))
+      (planck.io/as-file (.getPath u))
+      (throw (js/Error. (str "Not a file: " u))))))

--- a/planck-cljs/test/planck/http_test.cljs
+++ b/planck-cljs/test/planck/http_test.cljs
@@ -1,0 +1,118 @@
+(ns planck.http-test
+  (:require [cljs.test :refer-macros [deftest testing is]]
+            [planck.http]))
+
+(deftest request-test
+  (testing "request"
+    (is (every? (planck.http/request identity :get "url" {}) [:url :method :headers :timeout]))
+    (is (= planck.http/default-timeout
+           (:timeout (planck.http/request identity :get "url" {}))))
+    (is (= "GET" (:method (planck.http/request identity :get "url" {}))))
+    (is (= "url" (:url (planck.http/request identity :get "url" {}))))    
+    (is (= 30 (:timeout (planck.http/request identity :get "url" {:timeout 30}))))
+    (is (= "foo=bar" (:body (planck.http/request identity :get "url"
+                                                 {:form-params {:foo "bar"}}))))
+    (is (= (count "foo=bar") (-> (planck.http/request identity :get "url"
+                                                      {:form-params {:foo "bar"}})
+                                 (get-in [:headers :Content-length]))))
+    (let [params [["foo" "bar"]]
+          expected-body (planck.http/generate-multipart-body
+                         (planck.http/boundary planck.http/boundary-constant)
+                         (planck.http/generate-form-data params))]
+      (is (= (count expected-body) (-> (planck.http/request identity :get "url"
+                                                            {:multipart-params params})
+                                       :body
+                                       count)))
+      (is (= (count expected-body) (-> (planck.http/request identity :get "url"
+                                                            {:multipart-params params})
+                                       (get-in [:headers :Content-length])))))))
+
+(deftest generate-query-string-test
+  (testing "generate-query-string"
+    (is (= "foo=bar" (planck.http/generate-query-string {:foo "bar"})))
+    (let [q (planck.http/generate-query-string {:foo "bar" :bar "baz"})]
+      (is (or (= q "bar=baz&foo=bar") (= q "foo=bar&bar=baz")))) ;; same difference
+    (is (= "foo=b%3Dar" (planck.http/generate-query-string {:foo "b=ar"})))))
+
+(deftest wrap-content-type-test
+  (testing "wrap-content-type"
+    (is (= "application/json" (-> {:content-type :json :headers {}}
+                                   ((planck.http/wrap-content-type identity))
+                                   (get-in [:headers "Content-Type"]))))
+    (is (= "application/xml" (-> {:content-type :xml}
+                                   ((planck.http/wrap-content-type identity))
+                                   (get-in [:headers "Content-Type"]))))
+    (is (= "application/x-www-form-urlencoded" (-> {:content-type :form-urlencoded}
+                                                   ((planck.http/wrap-content-type identity))
+                                                   (get-in [:headers "Content-Type"]))))
+    (is (= "ugle" (-> {:content-type "ugle"}
+                      ((planck.http/wrap-content-type identity))
+                      (get-in [:headers "Content-Type"]))))
+    (is (= nil (-> {:content-type "ugle"}
+                      ((planck.http/wrap-content-type identity))
+                      :content-type)))
+    (is (= nil (-> {}
+                   ((planck.http/wrap-content-type identity))
+                   (get-in [:headers "Content-Type"]))))))
+
+(deftest wrap-accepts-test
+  (testing "wrap-accept"
+    (is (= "application/json" (-> {:accept :json}
+                                   ((planck.http/wrap-accepts identity))
+                                   (get-in [:headers "Accept"]))))
+    (is (= nil (-> {:accept :json}
+                   ((planck.http/wrap-accepts identity))
+                   :accept)))))
+
+(deftest wrap-content-length-test
+  (testing "wrap-content-length"
+    (is (= (count "uglepose") (-> {:body "uglepose"}
+                                 ((planck.http/wrap-add-content-length identity))
+                                 (get-in [:headers "Content-length"]))))))
+
+(deftest wrap-form-params-test
+  (testing "wrap-form-params"
+    (is (= nil (-> {:form-params "foo"}
+                   ((planck.http/wrap-form-params identity))
+                   :form-params)))
+    (is (= "foo=bar" (-> {:form-params {:foo "bar"}}
+                   ((planck.http/wrap-form-params identity))
+                   :body)))))
+
+(deftest generate-form-data-test
+  (testing "fileupload-stuff"
+    (let [expected (str planck.http/content-disposition "foo\"\n\nbar")]
+      (is (= [expected "--\n"]
+             (planck.http/generate-form-data [["foo" "bar"]]))))
+    (is (= [(str planck.http/content-disposition "foo\"; filename=\"bar\"\n"
+                 "Content-Type: application/octet-stream\n\n" "baz") "--\n"]
+           (planck.http/generate-form-data [["foo" ["baz" "bar"]]])))))
+
+(deftest generate-multipart-body-test
+  (testing "generate-multipart-body"
+    (is (= "boundarypart1\nboundarypart2"
+           (planck.http/generate-multipart-body "boundary" ["part1" "part2"])))))
+
+(deftest boundary-test
+  (testing "boundary"
+    (is (not= nil (re-matches #"u\d{10}" (planck.http/boundary "u"))))
+    (is (not= (planck.http/boundary "u") (planck.http/boundary "u")))))
+
+(deftest wrap-multipart-params-test
+  (testing "wrap-multipart-params"
+    (is (nil? (-> {:multipart-params [["foo" "bar"]]}
+                  ((planck.http/wrap-multipart-params identity))
+                  :multipart-params)))
+    (is ((not nil?) (-> {:multipart-params [["foo" "bar"]]}
+                        ((planck.http/wrap-multipart-params identity))
+                        :body)))
+    (is ((not nil?) (-> {:multipart-params [["foo" "bar"]]}
+                        ((planck.http/wrap-multipart-params identity))
+                        :content-type)))))
+
+(deftest wrap-throw-on-error-test
+  (testing "wrap-throw-on-error"
+    (is (= "Error: foo" (try (-> {:error "foo"}
+                                 ((planck.http/wrap-throw-on-error identity)))
+                             (catch js/Object e
+                               (.toString e)))))))

--- a/planck-cljs/test/planck/test_runner.cljs
+++ b/planck-cljs/test/planck/test_runner.cljs
@@ -3,11 +3,13 @@
             [planck.core-test]
             [planck.io-test]
             [planck.shell-test]
-            [planck.repl-test]))
+            [planck.repl-test]
+            [planck.http-test]))
 
 (defn run-all-tests []
   (run-tests
     'planck.core-test
     'planck.io-test
     'planck.shell-test
-    'planck.repl-test))
+    'planck.repl-test
+    'planck.http-test))

--- a/site/src/emacs.md
+++ b/site/src/emacs.md
@@ -10,11 +10,13 @@ so
 [Bozhidar Batsov](http://batsov.com) went ahead and created
 [inf-clojure](https://github.com/clojure-emacs/inf-clojure).
 
+
 ### Setup
 
 To set up `inf-clojure` to run with Planck, you can follow the
 instructions [here](https://github.com/clojure-emacs/inf-clojure) and
 add
+
 
 ```
 (setq inf-clojure-program "planck")


### PR DESCRIPTION
This is just a very rough draft to address #230 

Eventually I'm hoping for something like 

```clojure
(js/PLANCK_REQUEST (clj->js {"url" "http://planck-repl.org" "method" "GET" "headers" {..}}))
````

And then some wrapper code in Clojurescript