### PR TITLE
Fix multipart-params usage docstring

### DIFF
--- a/planck-cljs/src/planck/http.cljs
+++ b/planck-cljs/src/planck/http.cljs
@@ -208,9 +208,10 @@
          (atom nil)))))
   (make-writer [url opts]
     (planck.core/->Writer
-     (fn [s]
-       (post url {:multipart-params [[(or (:param-name opts) "file")
-                                      [s (or (:filename opts) "file.pnk")]]]})
+     (fn [content]
+       (let [name (or (:param-name opts) "file")
+             filename (or (:filename opts) "file.pnk")]
+         (post url {:multipart-params [[name [content filename]]]}))
        nil)
      (fn [])
      (fn []))))

--- a/planck-cljs/src/planck/http.cljs
+++ b/planck-cljs/src/planck/http.cljs
@@ -191,7 +191,7 @@
   :form-params, a map, will become the body of the request, urlencoded
   :multipart-params, a list of tuples, used for file-upload
                      {:multipart-params [[\"name\" \"value\"]
-                                         [\"name\" \"content\" \"filename\"]"
+                                         [\"name\" [\"content\" \"filename\"]]"
   ([url] (post url {}))
   ([url opts] (request js/PLANCK_REQUEST :post url opts)))
 


### PR DESCRIPTION
If you check the diff, you can see where the docstring was wrong.  Should be easier to catch this sort of thing with what I added in the second commit (named expressions instead of inline).

@slipset: just a heads-up