### PR TITLE
Start port of Planck to C

### DIFF
--- a/planck-c/.gitignore
+++ b/planck-c/.gitignore
@@ -1,0 +1,15 @@
+/planck
+/bundle-test
+/zip-test
+/*.o
+/*.tar.gz
+
+/linenoise.c
+/linenoise.h
+/jsc-funcs
+
+/.planck_cache
+/out
+
+/*.js
+/*.jar

--- a/planck-c/CHANGELOG.md
+++ b/planck-c/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## Unreleased
+
+## 0.0.2: Baby Steps
+
+- support for `--init` (i.e. at least *some* support for running
+    code from files)
+- fancy banner like planck has (can be suppressed with `--quiet`)
+
+## 0.0.1: Initial release - Beware The Unknown
+
+- REPL using `planck.repl`
+- syntax highlighting of results
+- support for `--eval`
+- bundled dependencies, classpath (including JARs) work
+- build automation (`make bundle-and-build`)

--- a/planck-c/Makefile
+++ b/planck-c/Makefile
@@ -1,0 +1,56 @@
+.PHONY: build bundle-and-build release bundle-test zip-test clean
+
+VERSION = $(shell git describe --tags)
+
+CC = clang
+
+CFLAGS = -Wall -DDEBUG
+UNAME_S = $(shell uname -s)
+ifeq ($(UNAME_S),Linux)
+	DEPS = javascriptcoregtk-4.0 libzip
+	CFLAGS += $(shell pkg-config --cflags $(DEPS))
+	LIBFLAGS = $(shell pkg-config --libs $(DEPS))
+endif
+ifeq ($(UNAME_S),Darwin)
+	LIBFLAGS += -lJavaScriptCore -lzip -lz
+endif
+CFLAGS += $(EXTRA_CFLAGS)
+
+SOURCES = $(sort $(wildcard *.c) linenoise.c)
+OBJECTS = $(SOURCES:.c=.o)
+
+# Build only the binary
+build: planck
+
+# Bundle cljs dependencies and build with that
+bundle-and-build:
+	cd ..; ./script/build-c
+
+# Build release tarball
+release:
+	git archive --prefix=planck-$(VERSION)/ --output=planck-$(VERSION).tar HEAD
+	# add bundle.c (with deps) and linenoise
+	tar -uf planck-$(VERSION).tar --transform='s/^/planck-$(VERSION)\//' bundle.c linenoise.c linenoise.h
+	gzip --force planck-$(VERSION).tar
+
+
+planck: $(OBJECTS)
+	$(CC) $(LIBFLAGS) $(OBJECTS) -o $@
+
+linenoise.c: linenoise.h
+	curl -LsSfo $@ https://github.com/antirez/linenoise/raw/master/linenoise.c
+
+linenoise.h:
+	curl -LsSfo $@ https://github.com/antirez/linenoise/raw/master/linenoise.h
+
+bundle-test:
+	$(CC) -lz -DBUNDLE_TEST bundle.c -o $@
+
+zip-test:
+	$(CC) $(shell pkg-config --cflags --libs libzip) -DZIP_TEST zip.c -o $@
+
+clean:
+	rm -f planck bundle-test zip-test $(OBJECTS)
+
+jsc-funcs:
+	grep -Rh JS_EXPORT /usr/include/webkitgtk-4.0/JavaScriptCore | sed 's/^JS_EXPORT //' | grep -v '^#' > $@

--- a/planck-c/README.md
+++ b/planck-c/README.md
@@ -1,0 +1,23 @@
+# planck-c
+
+This is an in-progress port of Planck to C, supporting multiple
+platforms.
+
+**Warning:** *This is very much a work in progress.  Lots of stuff is still missing, things might not work, ...  Feel free to port things from the Objective-C version of planck.*
+
+## Development
+
+- install `javascriptcore`, `libzip`, `zlib`
+    - on mac: `brew install libzip`
+    - on arch: `pacman -S webkit2gtk libzip zlib`
+- `make bundle-and-build`
+- have fun: `./planck`
+
+## Implementation
+
+- based on JavaScriptCore (from webkitgtk)
+- uses `planck-cljs`
+- access to native capabilities via a reimplementation of
+    planck's Objective-C part
+
+A lot of stuff is still missing (in fact most of it).

--- a/planck-c/bundle.c
+++ b/planck-c/bundle.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+
+#include "bundle_inflate.h"
+
+char *bundle_get_contents(char *path) {
+	fprintf(stderr, "WARN: no bundled sources, need to run script/bundle-c\n");
+	return NULL;
+}
+
+#ifdef BUNDLE_TEST
+int main(void) {
+	fprintf(stderr, "no bundled sources, need to run run script/bundle-c\n");
+	return -1;
+}
+#endif

--- a/planck-c/bundle.h
+++ b/planck-c/bundle.h
@@ -1,0 +1,1 @@
+char *bundle_get_contents(char *path);

--- a/planck-c/bundle_inflate.h
+++ b/planck-c/bundle_inflate.h
@@ -1,0 +1,43 @@
+#include <assert.h>
+#include <stdio.h>
+#include <stdbool.h>
+
+#include <zlib.h>
+
+int bundle_inflate(char *dest, unsigned char *src, unsigned int src_len, unsigned int len) {
+	if (src_len == 0) {
+		return 0;
+	}
+
+	bool done = false;
+	int status;
+
+	z_stream strm;
+    strm.next_in = src;
+    strm.avail_in = src_len;
+    strm.total_out = 0;
+    strm.zalloc = Z_NULL;
+    strm.zfree = Z_NULL;
+
+	if (inflateInit2(&strm, (15+32)) != Z_OK) {
+		return -1;
+	}
+
+	while (!done) {
+		strm.next_out = (unsigned char *)dest + strm.total_out;
+		strm.avail_out = len - strm.total_out;
+
+		status = inflate(&strm, Z_SYNC_FLUSH);
+		if (status == Z_STREAM_END) {
+			done = true;
+		} else if (status != Z_OK) {
+			break;
+		}
+	}
+
+	if (inflateEnd(&strm) != Z_OK) {
+		return -1;
+	}
+
+	return done ? 0 : -1;
+}

--- a/planck-c/cljs.c
+++ b/planck-c/cljs.c
@@ -1,0 +1,214 @@
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <JavaScriptCore/JavaScript.h>
+
+#include "bundle.h"
+#include "io.h"
+#include "jsc_utils.h"
+#include "str.h"
+
+char *munge(char *s) {
+	int len = strlen(s);
+	int new_len = 0;
+	for (int i = 0; i < len; i++) {
+		switch (s[i]) {
+		case '!':
+			new_len += 6; // _BANG_
+			break;
+		case '?':
+			new_len += 7; // _QMARK_
+			break;
+		default:
+			new_len += 1;
+		}
+	}
+
+	char *ms = malloc((new_len+1) * sizeof(char));
+	int j = 0;
+	for (int i = 0; i < len; i++) {
+		switch (s[i]) {
+		case '-':
+			ms[j++] = '_';
+			break;
+		case '!':
+			ms[j++] = '_';
+			ms[j++] = 'B';
+			ms[j++] = 'A';
+			ms[j++] = 'N';
+			ms[j++] = 'G';
+			ms[j++] = '_';
+			break;
+		case '?':
+			ms[j++] = '_';
+			ms[j++] = 'Q';
+			ms[j++] = 'M';
+			ms[j++] = 'A';
+			ms[j++] = 'R';
+			ms[j++] = 'K';
+			ms[j++] = '_';
+			break;
+
+		default:
+			ms[j++] = s[i];
+		}
+	}
+	ms[new_len] = '\0';
+
+	return ms;
+}
+
+JSValueRef get_value_on_object(JSContextRef ctx, JSObjectRef obj, char *name) {
+	JSStringRef name_str = JSStringCreateWithUTF8CString(name);
+	JSValueRef val = JSObjectGetProperty(ctx, obj, name_str, NULL);
+	JSStringRelease(name_str);
+	return val;
+}
+
+JSValueRef get_value(JSContextRef ctx, char *namespace, char *name) {
+	JSValueRef ns_val = NULL;
+
+	// printf("get_value: '%s'\n", namespace);
+	int len = strlen(namespace) + 1;
+	char *ns_tmp = malloc(len * sizeof(char));
+	strncpy(ns_tmp, namespace, len);
+	char *ns_part = strtok(ns_tmp, ".");
+	ns_tmp = NULL;
+	while (ns_part != NULL) {
+		char *munged_ns_part = munge(ns_part);
+		if (ns_val) {
+			ns_val = get_value_on_object(ctx, JSValueToObject(ctx, ns_val, NULL), munged_ns_part);
+		} else {
+			ns_val = get_value_on_object(ctx, JSContextGetGlobalObject(ctx), munged_ns_part);
+		}
+		free(munged_ns_part); // TODO: Use a fixed buffer for this?  (Which would restrict namespace part length...)
+
+		ns_part = strtok(NULL, ".");
+	}
+	//free(ns_tmp);
+
+	char *munged_name = munge(name);
+	JSValueRef val = get_value_on_object(ctx, JSValueToObject(ctx, ns_val, NULL), munged_name);
+	free(munged_name);
+	return val;
+}
+
+JSObjectRef get_function(JSContextRef ctx, char *namespace, char *name) {
+	JSValueRef val = get_value(ctx, namespace, name);
+	assert(!JSValueIsUndefined(ctx, val));
+	return JSValueToObject(ctx, val, NULL);
+}
+
+JSValueRef evaluate_source(JSContextRef ctx, char *type, char *source, bool expression, bool print_nil, char *set_ns, char *theme) {
+	JSValueRef args[6];
+	int num_args = 6;
+
+	{
+		JSValueRef source_args[2];
+		JSStringRef type_str = JSStringCreateWithUTF8CString(type);
+		source_args[0] = JSValueMakeString(ctx, type_str);
+		JSStringRef source_str = JSStringCreateWithUTF8CString(source);
+		source_args[1] = JSValueMakeString(ctx, source_str);
+		args[0] = JSObjectMakeArray(ctx, 2, source_args, NULL);
+	}
+
+	args[1] = JSValueMakeBoolean(ctx, expression);
+	args[2] = JSValueMakeBoolean(ctx, print_nil);
+	JSValueRef set_ns_val = NULL;
+	if (set_ns != NULL) {
+		JSStringRef set_ns_str = JSStringCreateWithUTF8CString(set_ns);
+		set_ns_val = JSValueMakeString(ctx, set_ns_str);
+	}
+	args[3] = set_ns_val;
+	JSStringRef theme_str = JSStringCreateWithUTF8CString(theme);
+	args[4] = JSValueMakeString(ctx, theme_str);
+	args[5] = JSValueMakeNumber(ctx, 0);
+
+	JSObjectRef execute_fn = get_function(ctx, "planck.repl", "execute");
+	JSObjectRef global_obj = JSContextGetGlobalObject(ctx);
+	JSValueRef ex = NULL;
+	JSValueRef val = JSObjectCallAsFunction(ctx, execute_fn, global_obj, num_args, args, &ex);
+
+	// debug_print_value("planck.repl/execute", ctx, ex);
+
+	return ex != NULL ? ex : val;
+}
+
+void bootstrap(JSContextRef ctx, char *out_path) {
+	char *deps_file_path = "main.js";
+	char *goog_base_path = "goog/base.js";
+	if (out_path != NULL) {
+		deps_file_path = str_concat(out_path, deps_file_path);
+		goog_base_path = str_concat(out_path, goog_base_path);
+	}
+
+	char source[] = "<bootstrap>";
+
+	// Setup CLOSURE_IMPORT_SCRIPT
+	evaluate_script(ctx, "CLOSURE_IMPORT_SCRIPT = function(src) { AMBLY_IMPORT_SCRIPT('goog/' + src); return true; }", source);
+
+	// Load goog base
+	char *base_script_str = NULL;
+	if (out_path) {
+		base_script_str = get_contents(goog_base_path, NULL);
+		free(goog_base_path);
+	} else {
+		base_script_str = bundle_get_contents(goog_base_path);
+	}
+	if (base_script_str == NULL) {
+		fprintf(stderr, "The goog base JavaScript text could not be loaded\n");
+		exit(1);
+	}
+	evaluate_script(ctx, base_script_str, "<bootstrap:base>");
+	free(base_script_str);
+
+	// Load the deps file
+	char *deps_script_str = NULL;
+	if (out_path) {
+		deps_script_str = get_contents(deps_file_path, NULL);
+		free(deps_file_path);
+	} else {
+		deps_script_str = bundle_get_contents(deps_file_path);
+	}
+	if (deps_script_str == NULL) {
+		fprintf(stderr, "The deps JavaScript text could not be loaded\n");
+		exit(1);
+	}
+	evaluate_script(ctx, deps_script_str, "<bootstrap:deps>");
+	free(deps_script_str);
+
+	evaluate_script(ctx, "goog.isProvided_ = function(x) { return false; };", source);
+
+	evaluate_script(ctx, "goog.require = function (name) { return CLOSURE_IMPORT_SCRIPT(goog.dependencies_.nameToPath[name]); };", source);
+
+	evaluate_script(ctx, "goog.require('cljs.core');", source);
+
+	// redef goog.require to track loaded libs
+	evaluate_script(ctx, "cljs.core._STAR_loaded_libs_STAR_ = cljs.core.into.call(null, cljs.core.PersistentHashSet.EMPTY, [\"cljs.core\"]);\n"
+			"goog.require = function (name, reload) {\n"
+			"    if(!cljs.core.contains_QMARK_(cljs.core._STAR_loaded_libs_STAR_, name) || reload) {\n"
+			"        var AMBLY_TMP = cljs.core.PersistentHashSet.EMPTY;\n"
+			"        if (cljs.core._STAR_loaded_libs_STAR_) {\n"
+			"            AMBLY_TMP = cljs.core._STAR_loaded_libs_STAR_;\n"
+			"        }\n"
+			"        cljs.core._STAR_loaded_libs_STAR_ = cljs.core.into.call(null, AMBLY_TMP, [name]);\n"
+			"        CLOSURE_IMPORT_SCRIPT(goog.dependencies_.nameToPath[name]);\n"
+			"    }\n"
+			"};", source);
+}
+
+void run_main_in_ns(JSContextRef ctx, char *ns, int argc, char **argv) {
+	int num_arguments = argc + 1;
+	JSValueRef arguments[num_arguments];
+	JSValueRef result;
+	arguments[0] = c_string_to_value(ctx, ns);
+	for (int i=1; i<num_arguments; i++) {
+		arguments[i] = c_string_to_value(ctx, argv[i-1]);
+	}
+
+	JSObjectRef global_obj = JSContextGetGlobalObject(ctx);
+	JSObjectRef run_main_fn = get_function(ctx, "planck.repl", "run-main");
+	result = JSObjectCallAsFunction(ctx, run_main_fn, global_obj, num_arguments, arguments, NULL);
+}

--- a/planck-c/cljs.h
+++ b/planck-c/cljs.h
@@ -1,0 +1,9 @@
+#include <JavaScriptCore/JavaScript.h>
+
+JSValueRef evaluate_source(JSContextRef ctx, char *type, char *source_value, bool expression, bool print_nil, char *set_ns, char *theme);
+char *munge(char *s);
+
+void bootstrap(JSContextRef ctx, char *out_path);
+JSObjectRef get_function(JSContextRef ctx, char *namespace, char *name);
+
+void run_main_in_ns(JSContextRef ctx, char *ns, int argc, char **argv);

--- a/planck-c/io.c
+++ b/planck-c/io.c
@@ -1,0 +1,117 @@
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <sys/stat.h>
+
+#define CHUNK_SIZE 1024
+
+char *read_all(FILE *f) {
+	int len = CHUNK_SIZE + 1;
+	char *buf = malloc(len * sizeof(char));
+
+	int offset = 0;
+	for (;;) {
+		if (len - offset < CHUNK_SIZE) {
+			len = 2 * len + CHUNK_SIZE;
+			buf = realloc(buf, len * sizeof(char));
+		}
+		int n = fread(buf + offset, 1, CHUNK_SIZE, f);
+		offset += n;
+		if (feof(f)) {
+			break;
+		}
+		if (ferror(f)) {
+			// fprintf(stderr, "Error: %s: %s\n", __func__, strerror(errno));
+			return NULL;
+		}
+	}
+	memset(buf + offset, 0, len - offset);
+	return buf;
+}
+
+char *get_contents(char *path, time_t *last_modified) {
+/*#ifdef DEBUG
+	printf("get_contents(\"%s\")\n", path);
+#endif*/
+
+	char *err_prefix;
+
+	FILE *f = fopen(path, "r");
+	if (f == NULL) {
+		err_prefix = "fopen";
+		goto err;
+	}
+
+	struct stat f_stat;
+	if (fstat(fileno(f), &f_stat) < 0) {
+		err_prefix = "fstat";
+		goto err;
+	}
+
+	if (last_modified != NULL) {
+		*last_modified = f_stat.st_mtime;
+	}
+
+	char *buf = malloc(f_stat.st_size + 1);
+	memset(buf, 0, f_stat.st_size);
+	fread(buf, f_stat.st_size, 1, f);
+	buf[f_stat.st_size] = '\0';
+	if (ferror(f)) {
+		err_prefix = "fread";
+		free(buf);
+		goto err;
+	}
+
+	if (fclose(f) < 0) {
+		err_prefix = "fclose";
+		goto err;
+	}
+
+	return buf;
+
+err:
+	//printf("get_contents(\"%s\"): %s: %s\n", path, err_prefix, strerror(errno));
+	return NULL;
+}
+
+void write_contents(char *path, char *contents) {
+	char *err_prefix;
+
+	FILE *f = fopen(path, "w");
+	if (f == NULL) {
+		err_prefix = "fopen";
+		goto err;
+	}
+
+	int len = strlen(contents);
+	int offset = 0;
+	do {
+		int res = fwrite(contents+offset, 1, len-offset, f);
+		if (res < 0) {
+			err_prefix = "fwrite";
+			goto err;
+		}
+		offset += res;
+	} while (offset < len);
+
+	if (fclose(f) < 0) {
+		err_prefix = "fclose";
+		goto err;
+	}
+
+	return;
+
+err:
+	// printf("write_contents(\"%s\", ...): %s: %s\n", path, err_prefix, strerror(errno));
+	return;
+}
+
+int mkdir_p(char *path) {
+	int res = mkdir(path, 0755);
+	if (res < 0 && errno == EEXIST) {
+		return 0;
+	}
+	return res;
+}

--- a/planck-c/io.h
+++ b/planck-c/io.h
@@ -1,0 +1,6 @@
+#include <time.h>
+
+char *read_all(FILE *f);
+char* get_contents(char *path, time_t *last_modified);
+void write_contents(char *path, char *contents);
+int mkdir_p(char *path);

--- a/planck-c/jsc_utils.c
+++ b/planck-c/jsc_utils.c
@@ -1,0 +1,63 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <JavaScriptCore/JavaScript.h>
+
+JSStringRef to_string(JSContextRef ctx, JSValueRef val) {
+	if (JSValueIsUndefined(ctx, val)) {
+		return JSStringCreateWithUTF8CString("undefined");
+	} else if (JSValueIsNull(ctx, val)) {
+		return JSStringCreateWithUTF8CString("null");
+	} else {
+		JSStringRef to_string_name = JSStringCreateWithUTF8CString("toString");
+		JSObjectRef obj = JSValueToObject(ctx, val, NULL);
+		JSValueRef to_string = JSObjectGetProperty(ctx, obj, to_string_name, NULL);
+		JSObjectRef to_string_obj = JSValueToObject(ctx, to_string, NULL);
+		JSValueRef obj_val = JSObjectCallAsFunction(ctx, to_string_obj, obj, 0, NULL, NULL);
+
+		return JSValueToStringCopy(ctx, obj_val, NULL);
+	}
+}
+
+JSValueRef evaluate_script(JSContextRef ctx, char *script, char *source) {
+	JSStringRef script_ref = JSStringCreateWithUTF8CString(script);
+	JSStringRef source_ref = NULL;
+	if (source != NULL) {
+		source_ref = JSStringCreateWithUTF8CString(source);
+	}
+
+	JSValueRef ex = NULL;
+	JSValueRef val = JSEvaluateScript(ctx, script_ref, NULL, source_ref, 0, &ex);
+	JSStringRelease(script_ref);
+	if (source != NULL) {
+		JSStringRelease(source_ref);
+	}
+
+	// debug_print_value("evaluate_script", ctx, ex);
+
+	return val;
+}
+
+char *value_to_c_string(JSContextRef ctx, JSValueRef val) {
+	if (!JSValueIsString(ctx, val)) {
+#ifdef DEBUG
+		fprintf(stderr, "WARN: not a string\n");
+#endif
+		return NULL;
+	}
+
+	JSStringRef str_ref = JSValueToStringCopy(ctx, val, NULL);
+	size_t len = JSStringGetLength(str_ref) + 1;
+	char *str = malloc(len * sizeof(char));
+	memset(str, 0, len);
+	JSStringGetUTF8CString(str_ref, str, len);
+	JSStringRelease(str_ref);
+
+	return str;
+}
+
+JSValueRef c_string_to_value(JSContextRef ctx, char *s) {
+	JSStringRef str = JSStringCreateWithUTF8CString(s);
+	return JSValueMakeString(ctx, str);
+}

--- a/planck-c/jsc_utils.h
+++ b/planck-c/jsc_utils.h
@@ -1,0 +1,8 @@
+#include <JavaScriptCore/JavaScript.h>
+
+JSStringRef to_string(JSContextRef ctx, JSValueRef val);
+JSValueRef evaluate_script(JSContextRef ctx, char *script, char *source);
+
+char *value_to_c_string(JSContextRef ctx, JSValueRef val);
+
+JSValueRef c_string_to_value(JSContextRef ctx, char *s);

--- a/planck-c/legal.c
+++ b/planck-c/legal.c
@@ -1,0 +1,116 @@
+#include <stdio.h>
+
+void legal() {
+	printf("\n");
+	printf("Planck\n");
+	printf("------\n");
+	printf("\n");
+	printf("Copyright © 2015-2016 Mike Fikes and Contributors\n");
+	printf("Distributed under the Eclipse Public License either version 1.0 or (at your\n");
+	printf("option) any later version.\n");
+	printf("\n");
+	printf("\n");
+	printf("Portions of Planck may utilize the following copyrighted material, the use of\n");
+	printf("which is hereby acknowledged.\n");
+	printf("\n");
+	
+	// printf("Ambly\n");
+	// printf("-----\n");
+	// printf("\n");
+	// printf("Copyright © 2015 David Nolen\n");
+	// printf("Licensed under the Eclipse Public License.\n");
+	// printf("\n");
+	// printf("\n");
+	
+	printf("Fipp\n");
+	printf("-----\n");
+	printf("\n");
+	printf("Copyright © 2015 Brandon Bloom\n");
+	printf("Distributed under the Eclipse Public License, the same as Clojure.\n");
+	printf("\n");
+	printf("\n");
+	
+	printf("Linenoise\n");
+	printf("---------\n");
+	printf("\n");
+	printf("Copyright (c) 2010-2014, Salvatore Sanfilippo <antirez at gmail dot com>\n");
+	printf("Copyright (c) 2010-2013, Pieter Noordhuis <pcnoordhuis at gmail dot com>\n");
+	printf("\n");
+	printf("All rights reserved.\n");
+	printf("\n");
+	printf("Redistribution and use in source and binary forms, with or without\n");
+	printf("modification, are permitted provided that the following conditions are met:\n");
+	printf("\n");
+	printf("* Redistributions of source code must retain the above copyright notice,\n");
+	printf("this list of conditions and the following disclaimer.\n");
+	printf("\n");
+	printf("* Redistributions in binary form must reproduce the above copyright notice,\n");
+	printf("this list of conditions and the following disclaimer in the documentation\n");
+	printf("and/or other materials provided with the distribution.\n");
+	printf("\n");
+	printf("THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\" AND\n");
+	printf("ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED\n");
+	printf("WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\n");
+	printf("DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR\n");
+	printf("ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES\n");
+	printf("(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;\n");
+	printf("LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON\n");
+	printf("ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n");
+	printf("(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS\n");
+	printf("SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n");
+	printf("\n");
+	printf("\n");
+	
+	// printf("MPEdn\n");
+	// printf("-----\n");
+	// printf("\n");
+	// printf("Developed by Matthew Phillips\n");
+	// printf("Licensed under the Eclipse Public License v1.0.\n");
+	// printf("\n");
+	// printf("\n");
+	
+	printf("Parinfer\n");
+	printf("-----\n");
+	printf("\n");
+	printf("Copyright (c) 2015 Shaun Williams and contributors\n");
+	printf("MIT License\n");
+	printf("\n");
+	printf("\n");
+	
+	printf("Pretty (ANSI portion, ported for ClojureScript)\n");
+	printf("-----------------------------------------------\n");
+	printf("\n");
+	printf("© Copyright 2013-2015, Aviso");
+	printf("\n");
+	printf("Apache Software License 2.0.\n");
+	printf("http://www.apache.org/licenses/LICENSE-2.0\n");
+	// printf("\n");
+	// printf("\n");
+	
+	// printf("ZipZap\n");
+	// printf("------\n");
+	// printf("\n");
+	// printf("Copyright (c) 2012, Pixelglow Software.\n");
+	// printf("All rights reserved.\n");
+	// printf("\n");
+	// printf("Redistribution and use in source and binary forms, with or without\n");
+	// printf("modification, are permitted provided that the following conditions are met:\n");
+	// printf("\n");
+	// printf("* Redistributions of source code must retain the above copyright notice,\n");
+	// printf("this list of conditions and the following disclaimer.\n");
+	// printf("\n");
+	// printf("* Redistributions in binary form must reproduce the above copyright notice,\n");
+	// printf("this list of conditions and the following disclaimer in the documentation\n");
+	// printf("and/or other materials provided with the distribution.\n");
+	// printf("\n");
+	// printf("THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\" AND\n");
+	// printf("ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED\n");
+	// printf("WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\n");
+	// printf("DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR\n");
+	// printf("ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES\n");
+	// printf("(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;\n");
+	// printf("LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON\n");
+	// printf("ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n");
+	// printf("(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS\n");
+	// printf("SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n");
+}

--- a/planck-c/legal.h
+++ b/planck-c/legal.h
@@ -1,0 +1,1 @@
+void legal();

--- a/planck-c/main.c
+++ b/planck-c/main.c
@@ -1,0 +1,809 @@
+#include <assert.h>
+#include <errno.h>
+#include <getopt.h>
+#include <libgen.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <JavaScriptCore/JavaScript.h>
+
+#include "linenoise.h"
+
+#include "bundle.h"
+#include "cljs.h"
+#include "io.h"
+#include "jsc_utils.h"
+#include "legal.h"
+#include "str.h"
+#include "zip.h"
+
+#define PLANCK_VERSION "0.0.2"
+
+#define CONSOLE_LOG_BUF_SIZE 1000
+char console_log_buf[CONSOLE_LOG_BUF_SIZE];
+
+bool is_tty = false;
+int exit_value = 0;
+struct src_path {
+	char *type;
+	char *path;
+};
+struct src_path *src_paths = NULL;
+int num_src_paths = 0;
+char *out_path = NULL;
+
+#ifdef DEBUG
+#define debug_print_value(prefix, ctx, val)	print_value(prefix ": ", ctx, val)
+#else
+#define debug_print_value(prefix, ctx, val)
+#endif
+
+void print_value(char *prefix, JSContextRef ctx, JSValueRef val) {
+	if (val != NULL) {
+		JSStringRef str = to_string(ctx, val);
+		char *ex_str = value_to_c_string(ctx, JSValueMakeString(ctx, str));
+		printf("%s%s\n", prefix, ex_str);
+		free(ex_str);
+	}
+}
+
+JSValueRef function_console_log(JSContextRef ctx, JSObjectRef function, JSObjectRef this_object,
+		size_t argc, const JSValueRef args[], JSValueRef* exception) {
+	for (int i = 0; i < argc; i++) {
+		if (i > 0) {
+			fprintf(stdout, " ");
+		}
+
+		JSStringRef str = to_string(ctx, args[i]);
+		JSStringGetUTF8CString(str, console_log_buf, CONSOLE_LOG_BUF_SIZE);
+		fprintf(stdout, "%s", console_log_buf);
+	}
+	fprintf(stdout, "\n");
+
+	return JSValueMakeUndefined(ctx);
+}
+
+JSValueRef function_console_error(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
+		size_t argc, const JSValueRef args[], JSValueRef* exception) {
+	for (int i = 0; i < argc; i++) {
+		if (i > 0) {
+			fprintf(stderr, " ");
+		}
+
+		JSStringRef str = to_string(ctx, args[i]);
+		JSStringGetUTF8CString(str, console_log_buf, CONSOLE_LOG_BUF_SIZE);
+		fprintf(stderr, "%s", console_log_buf);
+	}
+	fprintf(stderr, "\n");
+
+	return JSValueMakeUndefined(ctx);
+}
+
+JSValueRef function_read_file(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
+		size_t argc, const JSValueRef args[], JSValueRef* exception) {
+	// TODO: implement fully
+
+	if (argc == 1 && JSValueGetType(ctx, args[0]) == kJSTypeString) {
+		char path[100];
+		JSStringRef path_str = JSValueToStringCopy(ctx, args[0], NULL);
+		assert(JSStringGetLength(path_str) < 100);
+		JSStringGetUTF8CString(path_str, path, 100);
+		JSStringRelease(path_str);
+
+		// debug_print_value("read_file", ctx, args[0]);
+
+		time_t last_modified = 0;
+		char *contents = get_contents(path, &last_modified);
+		if (contents != NULL) {
+			JSStringRef contents_str = JSStringCreateWithUTF8CString(contents);
+			free(contents);
+
+			JSValueRef res[2];
+			res[0] = JSValueMakeString(ctx, contents_str);
+			res[1] = JSValueMakeNumber(ctx, last_modified);
+			return JSObjectMakeArray(ctx, 2, res, NULL);
+		}
+	}
+
+	return JSValueMakeNull(ctx);
+}
+
+JSValueRef function_load(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
+		size_t argc, const JSValueRef args[], JSValueRef* exception) {
+	// TODO: implement fully
+
+	if (argc == 1 && JSValueGetType(ctx, args[0]) == kJSTypeString) {
+		char path[100];
+		JSStringRef path_str = JSValueToStringCopy(ctx, args[0], NULL);
+		assert(JSStringGetLength(path_str) < 100);
+		JSStringGetUTF8CString(path_str, path, 100);
+		JSStringRelease(path_str);
+
+		// debug_print_value("load", ctx, args[0]);
+
+		time_t last_modified = 0;
+		char *contents = NULL;
+
+		bool developing = (num_src_paths == 1 &&
+		                   strcmp(src_paths[0].type, "src") == 0 &&
+		                   str_has_suffix(src_paths[0].path, "/planck-cljs/src/") == 0);
+
+		if (!developing) {
+			contents = bundle_get_contents(path);
+			last_modified = 0;
+		}
+
+		// load from classpath
+		if (contents == NULL) {
+			for (int i = 0; i < num_src_paths; i++) {
+				char *type = src_paths[i].type;
+				char *location = src_paths[i].path;
+
+				if (strcmp(type, "src") == 0) {
+					char *full_path = str_concat(location, path);
+					contents = get_contents(full_path, &last_modified);
+					free(full_path);
+				} else if (strcmp(type, "jar") == 0) {
+					contents = get_contents_zip(location, path, &last_modified);
+				}
+
+				if (contents != NULL) {
+					break;
+				}
+			}
+		}
+
+		// load from out/
+		if (contents == NULL) {
+			if (out_path != NULL) {
+				char *full_path = str_concat(out_path, path);
+				contents = get_contents(full_path, &last_modified);
+				free(full_path);
+			}
+		}
+
+		if (developing && contents == NULL) {
+			contents = bundle_get_contents(path);
+			last_modified = 0;
+		}
+
+		if (contents != NULL) {
+			JSStringRef contents_str = JSStringCreateWithUTF8CString(contents);
+			free(contents);
+
+			JSValueRef res[2];
+			res[0] = JSValueMakeString(ctx, contents_str);
+			res[1] = JSValueMakeNumber(ctx, last_modified);
+			return JSObjectMakeArray(ctx, 2, res, NULL);
+		}
+	}
+
+	return JSValueMakeNull(ctx);
+}
+
+JSValueRef function_load_deps_cljs_files(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
+		size_t argc, const JSValueRef args[], JSValueRef* exception) {
+	int num_files = 0;
+	char **deps_cljs_files = NULL;
+
+	if (argc == 0) {
+		for (int i = 0; i < num_src_paths; i++) {
+			char *type = src_paths[i].type;
+			char *location = src_paths[i].path;
+
+			if (strcmp(type, "jar") == 0) {
+				char *source = get_contents_zip(location, "deps.cljs", NULL);
+				if (source != NULL) {
+					num_files += 1;
+					deps_cljs_files = realloc(deps_cljs_files, num_files * sizeof(char*));
+					deps_cljs_files[num_files - 1] = source;
+				}
+			}
+		}
+	}
+
+	JSValueRef files[num_files];
+	for (int i = 0; i < num_files; i++) {
+		JSStringRef file = JSStringCreateWithUTF8CString(deps_cljs_files[i]);
+		files[i] = JSValueMakeString(ctx, file);
+		free(deps_cljs_files[i]);
+	}
+	free(deps_cljs_files);
+
+	return JSObjectMakeArray(ctx, num_files, files, NULL);
+}
+
+JSValueRef function_cache(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
+		size_t argc, const JSValueRef args[], JSValueRef* exception) {
+	if (argc == 4 &&
+			JSValueGetType (ctx, args[0]) == kJSTypeString &&
+			JSValueGetType (ctx, args[1]) == kJSTypeString &&
+			(JSValueGetType (ctx, args[2]) == kJSTypeString
+				|| JSValueGetType (ctx, args[2]) == kJSTypeNull) &&
+			(JSValueGetType (ctx, args[3]) == kJSTypeString
+				|| JSValueGetType (ctx, args[3]) == kJSTypeNull)) {
+		// debug_print_value("cache", ctx, args[0]);
+
+		char *cache_prefix = value_to_c_string(ctx, args[0]);
+		char *source = value_to_c_string(ctx, args[1]);
+		char *cache = value_to_c_string(ctx, args[2]);
+		char *sourcemap = value_to_c_string(ctx, args[3]);
+
+		char *suffix = NULL;
+		int max_suffix_len = 20;
+		int prefix_len = strlen(cache_prefix);
+		char *path = malloc((prefix_len + max_suffix_len) * sizeof(char));
+		memset(path, 0, prefix_len + max_suffix_len);
+
+		suffix = ".js";
+		strcpy(path, cache_prefix);
+		strcat(path, suffix);
+		write_contents(path, source);
+
+		suffix = ".cache.json";
+		strcpy(path, cache_prefix);
+		strcat(path, suffix);
+		write_contents(path, cache);
+
+		suffix = ".js.map.json";
+		strcpy(path, cache_prefix);
+		strcat(path, suffix);
+		write_contents(path, sourcemap);
+
+		free(cache_prefix);
+		free(source);
+		free(cache);
+		free(sourcemap);
+
+		free(path);
+	}
+
+	return  JSValueMakeNull(ctx);
+}
+
+JSValueRef function_eval(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
+		size_t argc, const JSValueRef args[], JSValueRef* exception) {
+	JSValueRef val = NULL;
+
+	if (argc == 2
+		&& JSValueGetType(ctx, args[0]) == kJSTypeString
+		&& JSValueGetType(ctx, args[1]) == kJSTypeString) {
+		// debug_print_value("eval", ctx, args[0]);
+
+		JSStringRef sourceRef = JSValueToStringCopy(ctx, args[0], NULL);
+		JSStringRef pathRef = JSValueToStringCopy(ctx, args[1], NULL);
+
+		JSEvaluateScript(ctx, sourceRef, NULL, pathRef, 0, &val);
+
+		JSStringRelease(pathRef);
+		JSStringRelease(sourceRef);
+	}
+
+	return val != NULL ? val : JSValueMakeNull(ctx);
+}
+
+JSValueRef function_get_term_size(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
+		size_t argc, const JSValueRef args[], JSValueRef* exception) {
+	// if (return_term_size)
+	struct winsize w;
+	ioctl(STDOUT_FILENO, TIOCGWINSZ, &w);
+	JSValueRef  arguments[2];
+	arguments[0] = JSValueMakeNumber(ctx, w.ws_row);
+	arguments[1] = JSValueMakeNumber(ctx, w.ws_col);
+	return JSObjectMakeArray(ctx, 2, arguments, NULL);
+	// return JSValueMakeNull(ctx);
+}
+
+JSValueRef function_print_fn(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
+		size_t argc, const JSValueRef args[], JSValueRef* exception) {
+	if (argc == 1 && JSValueIsString(ctx, args[0])) {
+		char *str = value_to_c_string(ctx, args[0]);
+
+		fprintf(stdout, "%s", str);
+		fflush(stdout);
+
+		free(str);
+	}
+
+	return JSValueMakeNull(ctx);
+}
+
+JSValueRef function_print_err_fn(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
+		size_t argc, const JSValueRef args[], JSValueRef* exception) {
+	if (argc == 1 && JSValueIsString(ctx, args[0])) {
+		char *str = value_to_c_string(ctx, args[0]);
+
+		fprintf(stderr, "%s", str);
+		fflush(stderr);
+
+		free(str);
+	}
+
+	return JSValueMakeNull(ctx);
+}
+
+JSValueRef function_set_exit_value(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
+		size_t argc, const JSValueRef args[], JSValueRef* exception) {
+	if (argc == 1 && JSValueGetType (ctx, args[0]) == kJSTypeNumber) {
+		exit_value = JSValueToNumber(ctx, args[0], NULL);
+	}
+	return JSValueMakeNull(ctx);
+}
+
+JSValueRef function_raw_read_stdin(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
+		size_t argc, const JSValueRef args[], JSValueRef* exception) {
+	char buf[1024 + 1];
+
+	int n = fread(buf, 1, is_tty ? 1 : 1024, stdin);
+	if (n > 0) {
+		buf[n] = '\0';
+		return c_string_to_value(ctx, buf);
+	}
+
+	return JSValueMakeNull(ctx);
+}
+
+JSValueRef function_raw_write_stdout(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
+		size_t argc, const JSValueRef args[], JSValueRef* exception) {
+	if (argc == 1 && JSValueGetType(ctx, args[0]) == kJSTypeString) {
+		char *s = value_to_c_string(ctx, args[0]);
+		fprintf(stdout, "%s", s);
+		free(s);
+	}
+
+	return JSValueMakeNull(ctx);
+}
+
+JSValueRef function_raw_flush_stdout(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
+		size_t argc, const JSValueRef args[], JSValueRef* exception) {
+	fflush(stdout);
+
+	return JSValueMakeNull(ctx);
+}
+
+JSValueRef function_raw_write_stderr(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
+		size_t argc, const JSValueRef args[], JSValueRef* exception) {
+	if (argc == 1 && JSValueGetType(ctx, args[0]) == kJSTypeString) {
+		char *s = value_to_c_string(ctx, args[0]);
+		fprintf(stderr, "%s", s);
+		free(s);
+	}
+
+	return JSValueMakeNull(ctx);
+}
+
+JSValueRef function_raw_flush_stderr(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
+		size_t argc, const JSValueRef args[], JSValueRef* exception) {
+	fflush(stderr);
+
+	return JSValueMakeNull(ctx);
+}
+
+JSValueRef function_import_script(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
+		size_t argc, const JSValueRef args[], JSValueRef* exception) {
+	if (argc == 1 && JSValueGetType(ctx, args[0]) == kJSTypeString) {
+		JSStringRef path_str_ref = JSValueToStringCopy(ctx, args[0], NULL);
+		assert(JSStringGetLength(path_str_ref) < 100);
+		char tmp[100];
+		tmp[0] = '\0';
+		JSStringGetUTF8CString(path_str_ref, tmp, 100);
+		JSStringRelease(path_str_ref);
+
+		char *path = tmp;
+		if (str_has_prefix(path, "goog/../") == 0) {
+			path = path + 8;
+		}
+
+		char *source = NULL;
+		if (out_path == NULL) {
+			source = bundle_get_contents(path);
+		} else {
+			char *full_path = str_concat(out_path, path);
+			source = get_contents(full_path, NULL);
+			free(full_path);
+		}
+
+		if (source != NULL) {
+			evaluate_script(ctx, source, path);
+			free(source);
+		}
+	}
+
+	return JSValueMakeUndefined(ctx);
+}
+
+void register_global_function(JSContextRef ctx, char *name, JSObjectCallAsFunctionCallback handler) {
+	JSObjectRef global_obj = JSContextGetGlobalObject(ctx);
+
+	JSStringRef fn_name = JSStringCreateWithUTF8CString(name);
+	JSObjectRef fn_obj = JSObjectMakeFunctionWithCallback(ctx, fn_name, handler);
+
+	JSObjectSetProperty(ctx, global_obj, fn_name, fn_obj, kJSPropertyAttributeNone, NULL);
+}
+
+void usage(char *program_name) {
+	printf("Planck %s\n", PLANCK_VERSION);
+	printf("Usage:  %s [init-opt*] [main-opt] [arg*]\n", program_name);
+	printf("\n");
+	printf("  With no options or args, runs an interactive Read-Eval-Print Loop\n");
+	printf("\n");
+	printf("  init options:\n");
+	printf("    -i path, --init=path     Load a file or resource\n");
+	printf("    -e string, --eval=string Evaluate expressions in string; print non-nil\n");
+	printf("                             values\n");
+	printf("    -c cp, --classpath=cp    Use colon-delimited cp for source directories and\n");
+	printf("                             JARs\n");
+	printf("    -K, --auto-cache         Create and use .planck_cache dir for cache\n");
+	printf("    -k path, --cache=path    If dir exists at path, use it for cache\n");
+	printf("    -q, --quiet              Quiet mode\n");
+	printf("    -v, --verbose            Emit verbose diagnostic output\n");
+	// printf("    -d, --dumb-terminal      Disable line editing / VT100 terminal control\n");
+	printf("    -t theme, --theme=theme  Set the color theme\n");
+	// printf("    -n x, --socket-repl=x    Enable socket REPL where x is port or IP:port\n");
+	printf("    -s, --static-fns         Generate static dispatch function calls\n");
+	printf("    -a, --elide-asserts      Set *assert* to false to remove asserts\n");
+	printf("\n");
+	printf("  main options:\n");
+	printf("    -m ns-name, --main=ns-name Call the -main function from a namespace with\n");
+	printf("                               args\n");
+	printf("    -r, --repl                 Run a repl\n");
+	// printf("    path                       Run a script from a file or resource\n");
+	// printf("    -                          Run a script from standard input\n");
+	printf("    -h, -?, --help             Print this help message and exit\n");
+	printf("    -l, --legal                Show legal info (licenses and copyrights)\n");
+	printf("\n");
+	printf("  operation:\n");
+	printf("\n");
+	printf("    - Enters the cljs.user namespace\n");
+	// printf("    - Binds planck.core/*command-line-args* to a seq of strings containing\n");
+	// printf("      command line args that appear after any main option\n");
+	printf("    - Runs all init options in order\n");
+	// printf("    - Calls a -main function or runs a repl or script if requested\n");
+	printf("    - Runs a repl or script if requested\n");
+	printf("\n");
+	printf("  The init options may be repeated and mixed freely, but must appear before\n");
+	printf("  any main option.\n");
+	printf("\n");
+	printf("  Paths may be absolute or relative in the filesystem.\n");
+	printf("\n");
+	printf("  A comprehensive User Guide for Planck can be found at http://planck-repl.org\n");
+	printf("\n");
+}
+
+char *get_cljs_version() {
+	char *bundle_js = bundle_get_contents("planck/bundle.js");
+	if (bundle_js != NULL) {
+		char *start = bundle_js + 29;
+		char *version = strtok(start, " ");
+		version = strdup(version);
+		free(bundle_js);
+		return version;
+	} else {
+		return "(Unknown)";
+	}
+}
+
+void banner() {
+	printf("Planck %s\n", PLANCK_VERSION);
+	printf("ClojureScript %s\n", get_cljs_version());
+
+	printf("    Docs: (doc function-name-here)\n");
+	printf("          (find-doc \"part-of-name-here\")\n");
+	printf("  Source: (source function-name-here)\n");
+	printf("    Exit: Control+D or :cljs/quit or exit or quit\n");
+	printf(" Results: Stored in vars *1, *2, *3, an exception in *e\n");
+
+	printf("\n");
+}
+
+bool verbose = false;
+bool quiet = false;
+bool repl = false;
+bool static_fns = false;
+bool elide_asserts = false;
+char *cache_path = NULL;
+char *theme = "light";
+char *main_ns_name = NULL;
+
+bool javascript = false;
+
+struct script {
+	char *type;
+	bool expression;
+	char *source;
+};
+struct script *scripts = NULL;
+int num_scripts = 0;
+
+int main(int argc, char **argv) {
+	struct option long_options[] = {
+		{"help", no_argument, NULL, 'h'},
+		{"legal", no_argument, NULL, 'l'},
+		{"verbose", no_argument, NULL, 'v'},
+		{"quiet", no_argument, NULL, 'q'},
+		{"repl", no_argument, NULL, 'r'},
+		{"static-fns", no_argument, NULL, 's'},
+		{"elide-asserts", no_argument, NULL, 'a'},
+		{"cache", required_argument, NULL, 'k'},
+		{"eval", required_argument, NULL, 'e'},
+		{"theme", required_argument, NULL, 't'},
+		{"classpath", required_argument, NULL, 'c'},
+		{"auto-cache", no_argument, NULL, 'K'},
+		{"init", required_argument, NULL, 'i'},
+		{"main", required_argument, NULL, 'm'},
+
+		// development options
+		{"javascript", no_argument, NULL, 'j'},
+		{"out", required_argument, NULL, 'o'},
+
+		{0, 0, 0, 0}
+	};
+	int opt, option_index;
+	while ((opt = getopt_long(argc, argv, "h?lvrsak:je:t:c:o:Ki:qm:", long_options, &option_index)) != -1) {
+		switch (opt) {
+		case 'h':
+			usage(argv[0]);
+			exit(0);
+		case 'l':
+			legal();
+			return 0;
+		case 'v':
+			verbose = true;
+			break;
+		case 'q':
+			quiet = true;
+			break;
+		case 'r':
+			repl = true;
+			break;
+		case 's':
+			static_fns = true;
+			break;
+		case 'a':
+			elide_asserts = true;
+			break;
+		case 'k':
+			cache_path = argv[optind - 1];
+			break;
+		case 'K':
+			cache_path = ".planck_cache";
+			{
+				char *path_copy = strdup(cache_path);
+				char *dir = dirname(path_copy);
+				if (mkdir_p(dir) < 0) {
+					fprintf(stderr, "Could not create %s: %s\n", cache_path, strerror(errno));
+				}
+				free(path_copy);
+			}
+			break;
+		case 'j':
+			javascript = true;
+			break;
+		case 'e':
+			num_scripts += 1;
+			scripts = realloc(scripts, num_scripts * sizeof(struct script));
+			scripts[num_scripts - 1].type = "text";
+			scripts[num_scripts - 1].expression = true;
+			scripts[num_scripts - 1].source = argv[optind - 1];
+			break;
+		case 'i':
+			num_scripts += 1;
+			scripts = realloc(scripts, num_scripts * sizeof(struct script));
+			scripts[num_scripts - 1].type = "path";
+			scripts[num_scripts - 1].expression = false;
+			scripts[num_scripts - 1].source = argv[optind - 1];
+			break;
+		case 'm':
+			main_ns_name = argv[optind - 1];
+		case 't':
+			theme = argv[optind - 1];
+			break;
+		case 'c':
+			{
+				char *classpath = argv[optind - 1];
+				char *source = strtok(classpath, ":");
+				while (source != NULL) {
+					char *type = "src";
+					if (str_has_suffix(source, ".jar") == 0) {
+						type = "jar";
+					}
+
+					num_src_paths += 1;
+					src_paths = realloc(src_paths, num_src_paths * sizeof(struct src_path));
+					src_paths[num_src_paths - 1].type = type;
+					src_paths[num_src_paths - 1].path = strdup(source);
+
+					source = strtok(NULL, ":");
+				}
+
+				break;
+			}
+		case 'o':
+			out_path = argv[optind - 1];
+			break;
+		case '?':
+			usage(argv[0]);
+			exit(1);
+		default:
+			printf("unhandled argument: %c\n", opt);
+		}
+	}
+
+	int num_rest_args = 0;
+	char **rest_args = NULL;
+	if (optind < argc) {
+		num_rest_args = argc - optind;
+		rest_args = malloc((argc - optind) * sizeof(char*));
+		int i = 0;
+		while (optind < argc) {
+			rest_args[i++] = argv[optind++];
+		}
+	}
+
+	if (num_scripts == 0 && main_ns_name == NULL && num_rest_args == 0) {
+		repl = true;
+	}
+
+	if (main_ns_name != NULL && repl) {
+		printf("Only one main-opt can be specified.");
+	}
+
+	JSGlobalContextRef ctx = JSGlobalContextCreate(NULL);
+
+	JSStringRef nameRef = JSStringCreateWithUTF8CString("planck");
+	JSGlobalContextSetName(ctx, nameRef);
+
+	evaluate_script(ctx, "var global = this;", "<init>");
+
+	register_global_function(ctx, "AMBLY_IMPORT_SCRIPT", function_import_script);
+	bootstrap(ctx, out_path);
+
+	register_global_function(ctx, "PLANCK_CONSOLE_LOG", function_console_log);
+	register_global_function(ctx, "PLANCK_CONSOLE_ERROR", function_console_error);
+
+	evaluate_script(ctx, "var console = {};"\
+			"console.log = PLANCK_CONSOLE_LOG;"\
+			"console.error = PLANCK_CONSOLE_ERROR;", "<init>");
+
+	evaluate_script(ctx, "var PLANCK_VERSION = \"" PLANCK_VERSION "\";", "<init>");
+
+	// require app namespaces
+	evaluate_script(ctx, "goog.require('planck.repl');", "<init>");
+
+	// without this things won't work
+	evaluate_script(ctx, "var window = global;", "<init>");
+
+	register_global_function(ctx, "PLANCK_READ_FILE", function_read_file);
+	register_global_function(ctx, "PLANCK_LOAD", function_load);
+	register_global_function(ctx, "PLANCK_LOAD_DEPS_CLJS_FILES", function_load_deps_cljs_files);
+	register_global_function(ctx, "PLANCK_CACHE", function_cache);
+
+	register_global_function(ctx, "PLANCK_EVAL", function_eval);
+
+	register_global_function(ctx, "PLANCK_GET_TERM_SIZE", function_get_term_size);
+	register_global_function(ctx, "PLANCK_PRINT_FN", function_print_fn);
+	register_global_function(ctx, "PLANCK_PRINT_ERR_FN", function_print_err_fn);
+
+	register_global_function(ctx, "PLANCK_SET_EXIT_VALUE", function_set_exit_value);
+
+	is_tty = isatty(STDIN_FILENO) == 1;
+	register_global_function(ctx, "PLANCK_RAW_READ_STDIN", function_raw_read_stdin);
+	register_global_function(ctx, "PLANCK_RAW_WRITE_STDOUT", function_raw_write_stdout);
+	register_global_function(ctx, "PLANCK_RAW_FLUSH_STDOUT", function_raw_flush_stdout);
+	register_global_function(ctx, "PLANCK_RAW_WRITE_STDERR", function_raw_write_stderr);
+	register_global_function(ctx, "PLANCK_RAW_FLUSH_STDERR", function_raw_flush_stderr);
+
+	{
+		JSValueRef arguments[num_rest_args];
+		for (int i = 0; i < num_rest_args; i++) {
+			arguments[i] = c_string_to_value(ctx, rest_args[i]);
+		}
+		JSValueRef args_ref = JSObjectMakeArray(ctx, num_rest_args, arguments, NULL);
+
+		JSValueRef global_obj = JSContextGetGlobalObject(ctx);
+		JSStringRef prop = JSStringCreateWithUTF8CString("PLANCK_INITIAL_COMMAND_LINE_ARGS");
+		JSObjectSetProperty(ctx, JSValueToObject(ctx, global_obj, NULL), prop, args_ref, kJSPropertyAttributeNone, NULL);
+		JSStringRelease(prop);
+	}
+
+	evaluate_script(ctx, "cljs.core.set_print_fn_BANG_.call(null,PLANCK_PRINT_FN);", "<init>");
+	evaluate_script(ctx, "cljs.core.set_print_err_fn_BANG_.call(null,PLANCK_PRINT_ERR_FN);", "<init>");
+
+	char *elide_script = str_concat("cljs.core._STAR_assert_STAR_ = ", elide_asserts ? "false" : "true");
+	evaluate_script(ctx, elide_script, "<init>");
+	free(elide_script);
+
+	{
+		JSValueRef arguments[4];
+		arguments[0] = JSValueMakeBoolean(ctx, repl);
+		arguments[1] = JSValueMakeBoolean(ctx, verbose);
+		JSValueRef cache_path_ref = NULL;
+		if (cache_path != NULL) {
+			JSStringRef cache_path_str = JSStringCreateWithUTF8CString(cache_path);
+			cache_path_ref = JSValueMakeString(ctx, cache_path_str);
+		}
+		arguments[2] = cache_path_ref;
+		arguments[3] = JSValueMakeBoolean(ctx, static_fns);
+		JSValueRef ex = NULL;
+		JSObjectCallAsFunction(ctx, get_function(ctx, "planck.repl", "init"), JSContextGetGlobalObject(ctx), 4, arguments, &ex);
+		debug_print_value("planck.repl/init", ctx, ex);
+	}
+
+	if (repl) {
+		evaluate_source(ctx, "text", "(require '[planck.repl :refer-macros [apropos dir find-doc doc source pst]])", true, false, "cljs.user", "dumb");
+	}
+
+	evaluate_script(ctx, "goog.provide('cljs.user');", "<init>");
+	evaluate_script(ctx, "goog.require('cljs.core');", "<init>");
+
+	evaluate_script(ctx, "cljs.core._STAR_assert_STAR_ = true;", "<init>");
+
+	// Process init arguments
+
+	for (int i = 0; i < num_scripts; i++) {
+		// TODO: exit if not successfull
+		evaluate_source(ctx, scripts[i].type, scripts[i].source, scripts[i].expression, false, NULL, theme);
+	}
+
+	// Process main arguments
+
+	if (main_ns_name != NULL) {
+		run_main_in_ns(ctx, main_ns_name, num_rest_args, rest_args);
+	} else if (!repl && num_rest_args > 0) {
+		char *path = rest_args[0];
+
+		struct script script;
+		if (strcmp(path, "-") == 0) {
+			char *source = read_all(stdin);
+			script.type = "text";
+			script.source = source;
+			script.expression = false;
+		} else {
+			script.type = "path";
+			script.source = path;
+			script.expression = false;
+		}
+
+		evaluate_source(ctx, script.type, script.source, script.expression, false, NULL, theme);
+	} else if (repl) {
+		if (!quiet) {
+			banner();
+		}
+
+		char *home = getenv("HOME");
+		char *history_path = NULL;
+		if (home != NULL) {
+			char history_name[] = ".planck_history";
+			int len = strlen(home) + strlen(history_name) + 2;
+			history_path = malloc(len * sizeof(char));
+			snprintf(history_path, len, "%s/%s", home, history_name);
+
+			linenoiseHistoryLoad(history_path);
+		}
+
+		char *prompt = javascript ? " > " : " => ";
+
+		char *line;
+		while ((line = linenoise(prompt)) != NULL) {
+			if (javascript) {
+				JSValueRef res = evaluate_script(ctx, line, "<stdin>");
+				print_value("", ctx, res);
+			} else {
+				evaluate_source(ctx, "text", line, true, true, "cljs.user", theme);
+			}
+			linenoiseHistoryAdd(line);
+			if (history_path != NULL) {
+				linenoiseHistorySave(history_path);
+			}
+			free(line);
+		}
+	}
+
+	return exit_value;
+}

--- a/planck-c/str.c
+++ b/planck-c/str.c
@@ -1,0 +1,35 @@
+#include <string.h>
+#include <stdlib.h>
+
+int str_has_suffix(char *str, char *suffix) {
+	int len = strlen(str);
+	int suffix_len = strlen(suffix);
+
+	if (len < suffix_len) {
+		return -1;
+	}
+
+	return strcmp(str + (len-suffix_len), suffix);
+}
+
+int str_has_prefix(char *str, char *prefix) {
+	int len = strlen(str);
+	int prefix_len = strlen(prefix);
+
+	if (len < prefix_len) {
+		return -1;
+	}
+
+	return strncmp(str, prefix, prefix_len);
+}
+
+char *str_concat(char *s1, char *s2) {
+	int l1 = strlen(s1), l2 = strlen(s2);
+	int len = l1 + l2 + 1;
+	char *s = malloc(len * sizeof(char));
+	memset(s, 0, len);
+
+	strncpy(s, s1, l1);
+	strncpy(s+l1, s2, l2);
+	return s;
+}

--- a/planck-c/str.h
+++ b/planck-c/str.h
@@ -1,0 +1,3 @@
+int str_has_suffix(char *str, char *suffix);
+int str_has_prefix(char *str, char *prefix);
+char *str_concat(char *s1, char *s2);

--- a/planck-c/zip.c
+++ b/planck-c/zip.c
@@ -1,0 +1,79 @@
+// Utilities for getting entries from ZIP files.
+// 
+// Uses libzip, alternatives are minizip (from zlib) and zziplib.
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "zip.h"
+
+void print_zip_err(char *prefix, zip_t *zip);
+
+char *get_contents_zip(char *path, char *name, time_t *last_modified) {
+	zip_t *archive = zip_open(path, ZIP_RDONLY, NULL);
+	if (archive == NULL) {
+		print_zip_err("zip_open", archive);
+		return NULL;
+	}
+
+	zip_stat_t stat;
+	if (zip_stat(archive, name, 0, &stat) < 0) {
+		print_zip_err("zip_stat", archive);
+		goto close_archive;
+	}
+
+	zip_file_t *f = zip_fopen(archive, name, 0);
+	if (f == NULL) {
+		print_zip_err("zip_fopen", archive);
+		goto close_archive;
+	}
+
+	if (last_modified != NULL) {
+		*last_modified = stat.mtime;
+	}
+
+	char *buf = malloc(stat.size + 1);
+	if (zip_fread(f, buf, stat.size) < 0) {
+		print_zip_err("zip_fread", archive);
+		goto free_buf;
+	}
+	buf[stat.size] = '\0';
+
+	zip_fclose(f);
+	zip_close(archive);
+
+	return buf;
+
+free_buf:
+	free(buf);
+	zip_fclose(f);
+close_archive:
+	zip_close(archive);
+
+	return NULL;
+}
+
+void print_zip_err(char *prefix, zip_t *zip) {
+		zip_error_t *err = zip_get_error(zip);
+		printf("%s: %s\n", prefix, zip_error_strerror(err));
+		zip_error_fini(err);
+}
+
+#ifdef ZIP_TEST
+int main(int argc, char **argv) {
+	if (argc != 3) {
+		printf("%s <zip-file> <path>\n", argv[0]);
+		return 1;
+	}
+
+	char *contents = get_contents_zip(argv[1], argv[2], NULL);
+	if (contents == NULL) {
+		return 1;
+	}
+
+	printf("%s", contents);
+	free(contents);
+
+	return 0;
+}
+#endif

--- a/planck-c/zip.h
+++ b/planck-c/zip.h
@@ -1,0 +1,3 @@
+#include <zip.h>
+
+char *get_contents_zip(char *path, char *name, time_t *last_modified);

--- a/planck-cljs/script/bundle-c
+++ b/planck-cljs/script/bundle-c
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+# Run this from the planck/planck-cljs directory
+
+# Make sure we fail and exit on the command that actually failed.
+set -e
+set -o pipefail
+
+cp src/planck/{repl,core,shell}.clj out/planck
+cp src/planck/from/io/aviso/ansi.clj out/planck/from/io/aviso
+
+cat <<EOF > bundle.c
+#include <stdlib.h>
+#include <string.h>
+
+#include <zlib.h>
+EOF
+
+cat <<EOF > bundle_dict.c
+unsigned char *bundle_path_to_addr(char *path, unsigned int *len, unsigned int *gz_len) {
+	if (path == NULL) {
+		return NULL;
+	}
+EOF
+
+cd out
+for file in `find . -name '*.js' -o -name '*.cljs' -o -name '*.cljc' -o -name '*.clj' -o -name '*.map' -o -name '*.json'`
+do 
+file=${file:2}
+cp $file $file.bak
+gzip -9 $file
+mv $file.bak $file
+filegz=$file.gz
+xxd -i $filegz >> ../bundle.c
+rm $filegz
+data_ref=${filegz//\//_}
+data_ref=${data_ref//\./_}
+data_ref=${data_ref//\$/_}
+file_size=`wc -c $file | cut -d' ' -f1`
+echo "unsigned int ${data_ref}_len_uncompressed = ${file_size};" >> ../bundle.c
+cat <<EOF >> ../bundle_dict.c
+	else if (strcmp("${file}", path) == 0) {
+		*gz_len = ${data_ref}_len;
+		*len = ${data_ref}_len_uncompressed;
+		return ${data_ref};
+	}
+EOF
+done
+cd ..
+cat <<EOF >> bundle_dict.c
+
+	return NULL;
+}
+EOF
+cat bundle_dict.c >> bundle.c
+cat <<EOF >> bundle.c
+#include "bundle_inflate.h"
+
+char *bundle_get_contents(char *path) {
+	unsigned int gz_len = 0;
+	unsigned int len = 0;
+	unsigned char *gz_data = bundle_path_to_addr(path, &len, &gz_len);
+
+	if (gz_data == NULL) {
+		return NULL;
+	}
+
+	char *contents = malloc((len + 1) * sizeof(char));
+	memset(contents, 0, len + 1);
+	int res = 0;
+	if ((res = bundle_inflate(contents, gz_data, gz_len, len)) < 0) {
+		free(contents);
+		return NULL;
+	}
+
+	return contents;
+}
+
+#ifdef BUNDLE_TEST
+#include <stdio.h>
+
+int main(int argc, char **argv) {
+	if (argc != 2) {
+		printf("%s <path>\n", argv[0]);
+		exit(1);
+	}
+
+	char *contents = bundle_get_contents(argv[1]);
+	if (contents == NULL) {
+		printf("not in bundle\n");
+		exit(1);
+	}
+
+	printf("%s", contents);
+	free(contents);
+
+	return 0;
+}
+#endif
+EOF
+rm bundle_dict.c
+mv bundle.c ../planck-c
+# We don't want git to suggest we commit this generated
+# output, so we suppress it here.
+if [ -d ../.git ]; then
+  git update-index --assume-unchanged ../planck-c/bundle.c
+fi;

--- a/script/build-c
+++ b/script/build-c
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+#----------------------------------------------------
+# Exit if the last command failed, indicating 
+# that there was a build failure
+#----------------------------------------------------
+checkCmdSuccess() {
+    CMD_RESULT=$?
+    if [ $CMD_RESULT != 0 ]; then
+        echo "Build Failed."
+        exit $CMD_RESULT 
+    fi
+}
+
+
+# ClojureScript
+cd planck-cljs
+echo "### Building ClojureScript"
+script/build
+checkCmdSuccess
+cd ..
+
+# Remove any leftover macros files so that they will not be bundled
+# We need them to be compiled by the 1st stage binary
+rm -f planck-cljs/out/planck/*macros*
+rm -f planck-cljs/out/planck/pprint/*macros*
+rm -f planck-cljs/out/clojure/template*macros*
+rm -f planck-cljs/out/cljs/test*macros*
+rm -f planck-cljs/out/cljs/spec*macros*
+rm -f planck-cljs/out/cljs/spec/impl/gen*macros*
+rm -f planck-cljs/out/planck/from/io/aviso/*macros*
+
+echo "### Bundling 1st Stage ClojureScript"
+cd planck-cljs
+script/bundle-c
+checkCmdSuccess
+cd ..
+
+echo "### Building 1st Stage Binary"
+cd planck-c
+make build
+cd ..
+checkCmdSuccess
+
+echo "### Compiling Macro Namespaces"
+mkdir -p planck-cljs/out/macros-tmp
+planck-c/planck -sk planck-cljs/out/macros-tmp -e "(require-macros 'planck.repl 'planck.core 'planck.shell 'planck.from.io.aviso.ansi 'clojure.template 'cljs.spec 'cljs.spec.impl.gen 'cljs.test)"
+
+mv planck-cljs/out/macros-tmp/planck_SLASH_repl\$macros.js planck-cljs/out/planck/repl\$macros.js
+mv planck-cljs/out/macros-tmp/planck_SLASH_repl\$macros.cache.json planck-cljs/out/planck/repl\$macros.cache.json
+mv planck-cljs/out/macros-tmp/planck_SLASH_repl\$macros.js.map.json planck-cljs/out/planck/repl\$macros.js.map.json
+mv planck-cljs/out/macros-tmp/planck_SLASH_core\$macros.js planck-cljs/out/planck/core\$macros.js
+mv planck-cljs/out/macros-tmp/planck_SLASH_core\$macros.cache.json planck-cljs/out/planck/core\$macros.cache.json
+mv planck-cljs/out/macros-tmp/planck_SLASH_core\$macros.js.map.json planck-cljs/out/planck/core\$macros.js.map.json
+mv planck-cljs/out/macros-tmp/planck_SLASH_shell\$macros.js planck-cljs/out/planck/shell\$macros.js
+mv planck-cljs/out/macros-tmp/planck_SLASH_shell\$macros.cache.json planck-cljs/out/planck/shell\$macros.cache.json
+mv planck-cljs/out/macros-tmp/planck_SLASH_shell\$macros.js.map.json planck-cljs/out/planck/shell\$macros.js.map.json
+mv planck-cljs/out/macros-tmp/planck_SLASH_from_SLASH_io_SLASH_aviso_SLASH_ansi\$macros.js planck-cljs/out/planck/from/io/aviso/ansi\$macros.js
+mv planck-cljs/out/macros-tmp/planck_SLASH_from_SLASH_io_SLASH_aviso_SLASH_ansi\$macros.cache.json planck-cljs/out/planck/from/io/aviso/ansi\$macros.cache.json
+mv planck-cljs/out/macros-tmp/planck_SLASH_from_SLASH_io_SLASH_aviso_SLASH_ansi\$macros.js.map.json planck-cljs/out/planck/from/io/aviso/ansi\$macros.js.map.json
+mv planck-cljs/out/macros-tmp/clojure_SLASH_template\$macros.js planck-cljs/out/clojure/template\$macros.js
+mv planck-cljs/out/macros-tmp/clojure_SLASH_template\$macros.cache.json planck-cljs/out/clojure/template\$macros.cache.json
+mv planck-cljs/out/macros-tmp/clojure_SLASH_template\$macros.js.map.json planck-cljs/out/clojure/template\$macros.js.map.json
+mv planck-cljs/out/macros-tmp/cljs_SLASH_test\$macros.js planck-cljs/out/cljs/test\$macros.js
+mv planck-cljs/out/macros-tmp/cljs_SLASH_test\$macros.cache.json planck-cljs/out/cljs/test\$macros.cache.json
+mv planck-cljs/out/macros-tmp/cljs_SLASH_test\$macros.js.map.json planck-cljs/out/planck/test\$macros.js.map.json
+mv planck-cljs/out/macros-tmp/cljs_SLASH_spec\$macros.js planck-cljs/out/cljs/spec\$macros.js
+mv planck-cljs/out/macros-tmp/cljs_SLASH_spec\$macros.cache.json planck-cljs/out/cljs/spec\$macros.cache.json
+mv planck-cljs/out/macros-tmp/cljs_SLASH_spec\$macros.js.map.json planck-cljs/out/cljs/spec\$macros.js.map.json
+mv planck-cljs/out/macros-tmp/cljs_SLASH_spec_SLASH_impl_SLASH_gen\$macros.js planck-cljs/out/cljs/spec/impl/gen\$macros.js
+mv planck-cljs/out/macros-tmp/cljs_SLASH_spec_SLASH_impl_SLASH_gen\$macros.cache.json planck-cljs/out/cljs/spec/impl/gen\$macros.cache.json
+mv planck-cljs/out/macros-tmp/cljs_SLASH_spec_SLASH_impl_SLASH_gen\$macros.js.map.json planck-cljs/out/cljs/spec/impl/gen\$macros.js.map.json
+
+rm -rf planck-cljs/out/macros-tmp
+
+echo "### Bundling ClojureScript"
+cd planck-cljs
+script/bundle-c
+checkCmdSuccess
+cd ..
+
+echo "### Building 2nd Stage Binary"
+cd planck-c
+make build
+cd ..
+checkCmdSuccess
+
+echo "Binary located at $PWD/planck-c/planck"


### PR DESCRIPTION
This is the start of a port of Planck to C.  Right now it has support
for the REPL (with syntax highlighting, basic line editing and history),
init and main opts, but not much more.

To build it, run `./script/build-c` from the top-level directory.

The code should support Linux and OSX, but was only tested on Linux.
BSDs should also be fairly easy to support in the future.

Things that are missing:

- anything requiring async and/or thread support
    (can be added using pthreads)

    This also means that there is currently no support for
    initialization in a thread, socket REPLs, ...
- encoding handling (so far, input is assumed to be UTF8)
- a lot of the exported js/PLANCK_* functions (see below)
- fancier REPL features (paren matching, live highlighting, ...)
- and more that I don't know about

The following js/PLANCK_* functions are still missing, although some of
them are fairly easy to add:

- js/PLANCK_DELETE
- js/PLANCK_FILE_INPUT_STREAM_CLOSE
- js/PLANCK_FILE_INPUT_STREAM_OPEN
- js/PLANCK_FILE_INPUT_STREAM_READ
- js/PLANCK_FILE_OUTPUT_STREAM_CLOSE
- js/PLANCK_FILE_OUTPUT_STREAM_OPEN
- js/PLANCK_FILE_OUTPUT_STREAM_WRITE
- js/PLANCK_FILE_READER_CLOSE
- js/PLANCK_FILE_READER_OPEN
- js/PLANCK_FILE_READER_READ
- js/PLANCK_FILE_WRITER_CLOSE
- js/PLANCK_FILE_WRITER_OPEN
- js/PLANCK_FILE_WRITER_WRITE
- js/PLANCK_FSTAT
- js/PLANCK_GET_EXIT_VALUE
- js/PLANCK_IS_DIRECTORY
- js/PLANCK_LIST_FILES
- js/PLANCK_READ_PASSWORD
- js/PLANCK_REQUEST
- js/PLANCK_SET_EXIT_VALUE
- js/PLANCK_VERSION