### PR TITLE
Add clang to the ArchLinux build instructions

### DIFF
--- a/planck-c/README.md
+++ b/planck-c/README.md
@@ -10,7 +10,7 @@ platforms.
 - prerequisites: Java, maven, lein
 - install `javascriptcore`, `libzip`, `zlib`
     - on mac: `brew install pkg-config libzip`
-    - on arch: `pacman -S webkit2gtk libzip zlib`
+    - on arch: `pacman -S clang webkit2gtk libzip zlib`
     - on Ubuntu 16.04: `sudo apt-get install clang javascriptcoregtk-4.0 libglib2.0-dev libzip-dev`
 - `make bundle-and-build`
 - have fun: `./planck`


### PR DESCRIPTION
`clang` is required for compilation, but not included in base install of ArchLinux.