### PR TITLE
Remove some unused variables and debug messages

### DIFF
--- a/planck-c/cljs.c
+++ b/planck-c/cljs.c
@@ -202,7 +202,6 @@ void bootstrap(JSContextRef ctx, char *out_path) {
 void run_main_in_ns(JSContextRef ctx, char *ns, int argc, char **argv) {
 	int num_arguments = argc + 1;
 	JSValueRef arguments[num_arguments];
-	JSValueRef result;
 	arguments[0] = c_string_to_value(ctx, ns);
 	for (int i=1; i<num_arguments; i++) {
 		arguments[i] = c_string_to_value(ctx, argv[i-1]);
@@ -210,5 +209,5 @@ void run_main_in_ns(JSContextRef ctx, char *ns, int argc, char **argv) {
 
 	JSObjectRef global_obj = JSContextGetGlobalObject(ctx);
 	JSObjectRef run_main_fn = get_function(ctx, "planck.repl", "run-main");
-	result = JSObjectCallAsFunction(ctx, run_main_fn, global_obj, num_arguments, arguments, NULL);
+	JSObjectCallAsFunction(ctx, run_main_fn, global_obj, num_arguments, arguments, NULL);
 }

--- a/planck-c/io.c
+++ b/planck-c/io.c
@@ -23,7 +23,6 @@ char *read_all(FILE *f) {
 			break;
 		}
 		if (ferror(f)) {
-			// fprintf(stderr, "Error: %s: %s\n", __func__, strerror(errno));
 			return NULL;
 		}
 	}
@@ -32,21 +31,13 @@ char *read_all(FILE *f) {
 }
 
 char *get_contents(char *path, time_t *last_modified) {
-/*#ifdef DEBUG
-	printf("get_contents(\"%s\")\n", path);
-#endif*/
-
-	char *err_prefix;
-
 	FILE *f = fopen(path, "r");
 	if (f == NULL) {
-		err_prefix = "fopen";
 		goto err;
 	}
 
 	struct stat f_stat;
 	if (fstat(fileno(f), &f_stat) < 0) {
-		err_prefix = "fstat";
 		goto err;
 	}
 
@@ -59,30 +50,24 @@ char *get_contents(char *path, time_t *last_modified) {
 	fread(buf, f_stat.st_size, 1, f);
 	buf[f_stat.st_size] = '\0';
 	if (ferror(f)) {
-		err_prefix = "fread";
 		free(buf);
 		goto err;
 	}
 
 	if (fclose(f) < 0) {
-		err_prefix = "fclose";
 		goto err;
 	}
 
 	return buf;
 
 err:
-	//printf("get_contents(\"%s\"): %s: %s\n", path, err_prefix, strerror(errno));
 	return NULL;
 }
 
 void write_contents(char *path, char *contents) {
-	char *err_prefix;
-
 	FILE *f = fopen(path, "w");
 	if (f == NULL) {
-		err_prefix = "fopen";
-		goto err;
+		return;
 	}
 
 	int len = strlen(contents);
@@ -90,21 +75,15 @@ void write_contents(char *path, char *contents) {
 	do {
 		int res = fwrite(contents+offset, 1, len-offset, f);
 		if (res < 0) {
-			err_prefix = "fwrite";
-			goto err;
+			return;
 		}
 		offset += res;
 	} while (offset < len);
 
 	if (fclose(f) < 0) {
-		err_prefix = "fclose";
-		goto err;
+		return;
 	}
 
-	return;
-
-err:
-	// printf("write_contents(\"%s\", ...): %s: %s\n", path, err_prefix, strerror(errno));
 	return;
 }
 


### PR DESCRIPTION
These were either not used at all, or only used for printf-debugging.
We might want a "trace" debug level, but using a debugger is probably
better.

(This also fixes warnings when compiling with gcc, which complained
about unused variables, unlike clang.)

We might want to return an error if `write_contents` fails, but it's
probably not necessary because `write_contents` is only used internally.
(I.e. in `PLANCK_CACHE`.)