### PR TITLE
Use custom linenoise from the obj-c version

### DIFF
--- a/planck-c/Makefile
+++ b/planck-c/Makefile
@@ -40,10 +40,10 @@ planck: $(OBJECTS)
 	$(CC) $(LIBFLAGS) $(OBJECTS) -o $@
 
 linenoise.c: linenoise.h
-	curl -LsSfo $@ https://github.com/antirez/linenoise/raw/master/linenoise.c
+	cp ../planck/linenoise/linenoise.c .
 
 linenoise.h:
-	curl -LsSfo $@ https://github.com/antirez/linenoise/raw/master/linenoise.h
+	cp ../planck/linenoise/linenoise.h .
 
 bundle-test:
 	$(CC) -lz -DBUNDLE_TEST bundle.c -o $@


### PR DESCRIPTION
We want a coloured prompt, which requires some changes in linenoise.c.
So we use the linenoise from planck, instead of the one from master.

You need to run `rm -f linenoise.*` in planck-c before this works.