### PR TITLE
Display current ns in REPL prompt

### DIFF
--- a/planck-c/cljs.c
+++ b/planck-c/cljs.c
@@ -211,3 +211,11 @@ void run_main_in_ns(JSContextRef ctx, char *ns, int argc, char **argv) {
 	JSObjectRef run_main_fn = get_function(ctx, "planck.repl", "run-main");
 	JSObjectCallAsFunction(ctx, run_main_fn, global_obj, num_arguments, arguments, NULL);
 }
+
+char *get_current_ns(JSContextRef ctx) {
+	int num_arguments = 0;
+	JSValueRef arguments[num_arguments];
+	JSObjectRef get_current_ns_fn = get_function(ctx, "planck.repl", "get-current-ns");
+	JSValueRef result = JSObjectCallAsFunction(ctx, get_current_ns_fn, JSContextGetGlobalObject(ctx), num_arguments, arguments, NULL);
+	return value_to_c_string(ctx, result);
+}

--- a/planck-c/cljs.h
+++ b/planck-c/cljs.h
@@ -7,3 +7,5 @@ void bootstrap(JSContextRef ctx, char *out_path);
 JSObjectRef get_function(JSContextRef ctx, char *namespace, char *name);
 
 void run_main_in_ns(JSContextRef ctx, char *ns, int argc, char **argv);
+
+char *get_current_ns();

--- a/planck-c/main.c
+++ b/planck-c/main.c
@@ -788,6 +788,10 @@ int main(int argc, char **argv) {
 		}
 
 		char *prompt = javascript ? " > " : "cljs.user=> ";
+		char *current_ns = get_current_ns(ctx);
+		if (!javascript) {
+			prompt = str_concat(current_ns, "=> ");
+		}
 
 		char *line;
 		while ((line = linenoise(prompt, "\x1b[36m", 0)) != NULL) {
@@ -795,7 +799,12 @@ int main(int argc, char **argv) {
 				JSValueRef res = evaluate_script(ctx, line, "<stdin>");
 				print_value("", ctx, res);
 			} else {
-				evaluate_source(ctx, "text", line, true, true, "cljs.user", theme);
+				evaluate_source(ctx, "text", line, true, true, current_ns, theme);
+				char *new_ns = get_current_ns(ctx);
+				free(current_ns);
+				free(prompt);
+				current_ns = new_ns;
+				prompt = str_concat(current_ns, "=> ");
 			}
 			linenoiseHistoryAdd(line);
 			if (history_path != NULL) {


### PR DESCRIPTION
This ports of `getCurrentNs` from `PLKClojureScriptEngine.m`, and uses it in `main.c` to display the current namespace.