### PR TITLE
Support planck.http in planck-c

### DIFF
--- a/planck-c/.gitignore
+++ b/planck-c/.gitignore
@@ -1,5 +1,6 @@
 /planck
 /bundle-test
+/http-test
 /zip-test
 /*.o
 /*.tar.gz

--- a/planck-c/Makefile
+++ b/planck-c/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build bundle-and-build release bundle-test zip-test clean
+.PHONY: build bundle-and-build release bundle-test http-test zip-test clean
 
 VERSION = $(shell git describe --tags)
 
@@ -7,12 +7,12 @@ CC = clang
 CFLAGS = -Wall -DDEBUG
 UNAME_S = $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
-	DEPS = javascriptcoregtk-4.0 libzip
+	DEPS = javascriptcoregtk-4.0 libzip libcurl
 	CFLAGS += $(shell pkg-config --cflags $(DEPS))
 	LIBFLAGS = $(shell pkg-config --libs $(DEPS))
 endif
 ifeq ($(UNAME_S),Darwin)
-	DEPS = libzip
+	DEPS = libzip libcurl
 	CFLAGS += $(shell pkg-config --cflags $(DEPS))
 	LIBFLAGS += -framework JavaScriptCore -lz $(shell pkg-config --libs $(DEPS))
 endif
@@ -37,7 +37,7 @@ release:
 
 
 planck: $(OBJECTS)
-	$(CC) $(LIBFLAGS) $(OBJECTS) -o $@
+	$(CC) $(CFLAGS) $(LIBFLAGS) $(OBJECTS) -o $@
 
 linenoise.c: linenoise.h
 	cp ../planck/linenoise/linenoise.c .
@@ -47,6 +47,9 @@ linenoise.h:
 
 bundle-test:
 	$(CC) -lz -DBUNDLE_TEST bundle.c -o $@
+
+http-test: jsc_utils.o
+	$(CC) $(shell pkg-config --cflags --libs javascriptcoregtk-3.0 libcurl) -DHTTP_TEST jsc_utils.o http.c -o $@
 
 zip-test:
 	$(CC) $(shell pkg-config --cflags --libs libzip) -DZIP_TEST zip.c -o $@

--- a/planck-c/http.c
+++ b/planck-c/http.c
@@ -1,0 +1,225 @@
+#include <assert.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <JavaScriptCore/JavaScript.h>
+
+#include <curl/curl.h>
+
+#include "jsc_utils.h"
+
+struct read_string_state {
+	char *input;
+	int offset;
+	int length;
+};
+
+size_t read_string_callback(char *buffer, size_t size, size_t nitems, void *instream) {
+	struct read_string_state *state = (struct read_string_state *)instream;
+
+	if (state->length > state->offset) {
+		return 0;
+	}
+
+	int n = 0;
+	if (state->offset + size * nitems < state->length) {
+		n = size * nitems;
+	} else {
+		n = state->length - state->offset;
+	}
+	memcpy(buffer, state->input + state->offset, n);
+	state->offset += n;
+
+	return n;
+}
+
+struct header_state {
+	JSContextRef ctx;
+	JSObjectRef headers;
+};
+
+size_t header_to_object_callback(char *buffer, size_t size, size_t nitems, void *userdata) {
+	struct header_state *state = (struct header_state*)userdata;
+
+	// printf("'%s'\n", buffer);
+
+	int key_end = -1;
+	int val_end = size * nitems;
+	for (int i = 0; i < size * nitems; i++) {
+		if (buffer[i] == ':' && key_end == -1) {
+			key_end = i;
+		}
+
+		if (buffer[i] == '\r' && buffer[i+1] == '\n') {
+			val_end = i;
+		}
+	}
+	if (key_end == -1) { // likely empty?
+		return size * nitems;
+	}
+
+	char key[key_end + 1];
+	strncpy(key, buffer, key_end);
+	key[key_end] = '\0';
+
+	JSStringRef key_str = JSStringCreateWithUTF8CString(key);
+
+	int val_start = key_end + 2;
+	int val_len = val_end - val_start;
+	char val[val_len];
+	strncpy(val, buffer + val_start, val_end - val_start);
+	val[val_len] = '\0';
+	JSStringRef val_str = JSStringCreateWithUTF8CString(val);
+	JSValueRef val_ref = JSValueMakeString(state->ctx, val_str);
+
+	JSObjectSetProperty(state->ctx, state->headers, key_str, val_ref, kJSPropertyAttributeReadOnly, NULL);
+
+	return size * nitems;
+}
+
+struct write_state {
+	int offset;
+	int length;
+	char *data;
+};
+
+size_t write_string_callback(char *buffer, size_t size, size_t nmemb, void
+*userdata) {
+	struct write_state *state = (struct write_state*)userdata;
+
+	if (state->length - state->offset < size * nmemb) {
+		int new_length = state->length * 2 + CURL_MAX_WRITE_SIZE;
+		if (state->length == 0) {
+			new_length += 1; // nul-byte
+		}
+		state->data = realloc(state->data, new_length);
+		state->length = new_length;
+	}
+
+	memcpy(state->data + state->offset, buffer, size * nmemb);
+	state->offset += size * nmemb;
+	state->data[state->offset] = '\0';
+
+	return size * nmemb;
+}
+
+JSValueRef function_http_request(JSContextRef ctx, JSObjectRef function, JSObjectRef this_object,
+		size_t argc, const JSValueRef args[], JSValueRef* exception) {
+	if (argc == 1 && JSValueGetType(ctx, args[0]) == kJSTypeObject) {
+		JSObjectRef opts = JSValueToObject(ctx, args[0], NULL);
+		JSValueRef url_ref = JSObjectGetProperty(ctx, opts, JSStringCreateWithUTF8CString("url"), NULL);
+		char *url = value_to_c_string(ctx, url_ref);
+		JSValueRef timeout_ref = JSObjectGetProperty(ctx, opts, JSStringCreateWithUTF8CString("timeout"), NULL);
+		time_t timeout = 0;
+		if (JSValueIsNumber(ctx, timeout_ref)) {
+			timeout = (time_t) JSValueToNumber(ctx, timeout_ref, NULL);
+		}
+		JSValueRef method_ref = JSObjectGetProperty(ctx, opts, JSStringCreateWithUTF8CString("method"), NULL);
+		char *method = value_to_c_string(ctx, method_ref);
+		JSValueRef body_ref = JSObjectGetProperty(ctx, opts, JSStringCreateWithUTF8CString("body"), NULL);
+
+		JSObjectRef headers_obj = JSValueToObject(ctx, JSObjectGetProperty(ctx, opts, JSStringCreateWithUTF8CString("headers"), NULL), NULL);
+
+		CURL *handle = curl_easy_init();
+		assert(handle != NULL);
+
+		curl_easy_setopt(handle, CURLOPT_CUSTOMREQUEST, method);
+		curl_easy_setopt(handle, CURLOPT_URL, url);
+
+		struct curl_slist *headers = NULL;
+		if (!JSValueIsNull(ctx, headers_obj)) {
+			JSPropertyNameArrayRef properties = JSObjectCopyPropertyNames(ctx, headers_obj);
+			int n = JSPropertyNameArrayGetCount(properties);
+			for (int i = 0; i < n; i++) {
+				JSStringRef key_str = JSPropertyNameArrayGetNameAtIndex(properties, i);
+				JSValueRef val_ref = JSObjectGetProperty(ctx, headers_obj, key_str, NULL);
+
+				int len = JSStringGetLength(key_str) + 1;
+				char *key = malloc(len * sizeof(char));
+				JSStringGetUTF8CString(key_str, key, len);
+				JSStringRef val_as_str = to_string(ctx, val_ref);
+				char *val = value_to_c_string(ctx, JSValueMakeString(ctx, val_as_str));
+				JSStringRelease(val_as_str);
+
+				int len_key = strlen(key);
+				int len_val = strlen(val);
+				char *header = malloc((len_key + len_val + 2 + 1) * sizeof(char));
+				sprintf(header, "%s: %s", key, val);
+				curl_slist_append(headers, header);
+				free(header);
+
+				free(key);
+				free(val);
+			}
+
+			curl_easy_setopt(handle, CURLOPT_HEADER, headers);
+		}
+
+		// curl_easy_setopt(handle, CURLOPT_HEADER, 1L);
+		curl_easy_setopt(handle, CURLOPT_TIMEOUT, timeout);
+
+		struct read_string_state input_state;
+		if (!JSValueIsUndefined(ctx, body_ref)) {
+			char *body = value_to_c_string(ctx, body_ref);
+			input_state.input = body;
+			input_state.offset = 0;
+			input_state.length = strlen(body);
+			curl_easy_setopt(handle, CURLOPT_READDATA, &input_state);
+			curl_easy_setopt(handle, CURLOPT_READFUNCTION, read_string_callback);
+		}
+
+		JSObjectRef response_headers = JSObjectMake(ctx, NULL, NULL);
+		struct header_state header_state;
+		header_state.ctx = ctx;
+		header_state.headers = response_headers;
+		curl_easy_setopt(handle, CURLOPT_HEADERDATA, &header_state);
+		curl_easy_setopt(handle, CURLOPT_HEADERFUNCTION, header_to_object_callback);
+
+		struct write_state body_state;
+		body_state.offset = 0;
+		body_state.length = 0;
+		body_state.data = NULL;
+		curl_easy_setopt(handle, CURLOPT_WRITEDATA, &body_state);
+		curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, write_string_callback);
+
+		JSObjectRef result = JSObjectMake(ctx, NULL, NULL);
+
+		int res = curl_easy_perform(handle);
+		if (res != 0) {
+			JSStringRef error_str = JSStringCreateWithUTF8CString(curl_easy_strerror(res));
+			JSObjectSetProperty(ctx, result, JSStringCreateWithUTF8CString("error"), JSValueMakeString(ctx, error_str), kJSPropertyAttributeReadOnly, NULL);
+		}
+
+		int status = 0;
+		curl_easy_getinfo(handle, CURLINFO_RESPONSE_CODE, &status);
+
+		printf("%d bytes, %x\n", body_state.offset, body_state.data);
+		if (body_state.data != NULL) {
+			JSStringRef body_str = JSStringCreateWithUTF8CString(body_state.data);
+			JSObjectSetProperty(ctx, result, JSStringCreateWithUTF8CString("body"), JSValueMakeString(ctx, body_str), kJSPropertyAttributeReadOnly, NULL);
+			free(body_state.data);
+		}
+
+		JSObjectSetProperty(ctx, result, JSStringCreateWithUTF8CString("status"), JSValueMakeNumber(ctx, status), kJSPropertyAttributeReadOnly, NULL);
+		JSObjectSetProperty(ctx, result, JSStringCreateWithUTF8CString("headers"), response_headers, kJSPropertyAttributeReadOnly, NULL);
+
+		curl_slist_free_all(headers);
+		curl_easy_cleanup(handle);
+
+		return result;
+	}
+
+	return JSValueMakeNull(ctx);
+}
+
+#ifdef HTTP_TEST
+int main(int argc, char **argv) {
+	CURL *curl = curl_easy_init();
+	if(curl) {
+		curl_easy_setopt(curl, CURLOPT_URL, "http://planck-repl.org");
+		curl_easy_setopt(curl, CURLOPT_HEADER, 1L);
+		curl_easy_perform(curl);
+	}
+}
+#endif

--- a/planck-c/http.h
+++ b/planck-c/http.h
@@ -1,0 +1,4 @@
+#include <JavaScriptCore/JavaScript.h>
+
+JSValueRef function_http_request(JSContextRef ctx, JSObjectRef function, JSObjectRef this_object,
+		size_t argc, const JSValueRef args[], JSValueRef* exception);

--- a/planck-c/main.c
+++ b/planck-c/main.c
@@ -17,6 +17,7 @@
 
 #include "bundle.h"
 #include "cljs.h"
+#include "http.h"
 #include "io.h"
 #include "jsc_utils.h"
 #include "legal.h"
@@ -703,6 +704,8 @@ int main(int argc, char **argv) {
 	register_global_function(ctx, "PLANCK_RAW_FLUSH_STDOUT", function_raw_flush_stdout);
 	register_global_function(ctx, "PLANCK_RAW_WRITE_STDERR", function_raw_write_stderr);
 	register_global_function(ctx, "PLANCK_RAW_FLUSH_STDERR", function_raw_flush_stderr);
+
+	register_global_function(ctx, "PLANCK_REQUEST", function_http_request);
 
 	{
 		JSValueRef arguments[num_rest_args];


### PR DESCRIPTION
This mostly works, but there is no support for NUL bytes in the response body yet, which is problematic when downloading binary data.

However, everything else should work.