### PR TITLE
Initialize ClojureScript in a background thread

### DIFF
--- a/planck-c/Makefile
+++ b/planck-c/Makefile
@@ -4,7 +4,7 @@ VERSION = $(shell git describe --tags)
 
 CC = clang
 
-CFLAGS = -Wall -DDEBUG
+CFLAGS = -Wall -DDEBUG -pthread
 UNAME_S = $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
 	DEPS = javascriptcoregtk-3.0 libzip libcurl

--- a/planck-c/cljs.c
+++ b/planck-c/cljs.c
@@ -385,6 +385,8 @@ void *cljs_do_engine_init(void *data) {
 void cljs_engine_init(JSContextRef ctx) {
 	sigset_t set;
 	sigemptyset(&set);
+	// FIXME: Figure out where SIGUSR2 comes from
+	//   (Without blocking SIGUSR2 things mysteriously don't work)
 	sigaddset(&set, SIGUSR2);
 	pthread_sigmask(SIG_BLOCK, &set, NULL);
 

--- a/planck-c/cljs.c
+++ b/planck-c/cljs.c
@@ -71,11 +71,8 @@ JSValueRef get_value(JSContextRef ctx, char *namespace, char *name) {
 	JSValueRef ns_val = NULL;
 
 	// printf("get_value: '%s'\n", namespace);
-	int len = strlen(namespace) + 1;
-	char *ns_tmp = malloc(len * sizeof(char));
-	strncpy(ns_tmp, namespace, len);
+	char *ns_tmp = strdup(namespace);
 	char *ns_part = strtok(ns_tmp, ".");
-	ns_tmp = NULL;
 	while (ns_part != NULL) {
 		char *munged_ns_part = munge(ns_part);
 		if (ns_val) {
@@ -87,7 +84,7 @@ JSValueRef get_value(JSContextRef ctx, char *namespace, char *name) {
 
 		ns_part = strtok(NULL, ".");
 	}
-	//free(ns_tmp);
+	free(ns_tmp);
 
 	char *munged_name = munge(name);
 	JSValueRef val = get_value_on_object(ctx, JSValueToObject(ctx, ns_val, NULL), munged_name);

--- a/planck-c/cljs.h
+++ b/planck-c/cljs.h
@@ -1,6 +1,6 @@
 #include <JavaScriptCore/JavaScript.h>
 
-JSValueRef evaluate_source(JSContextRef ctx, char *type, char *source_value, bool expression, bool print_nil, char *set_ns, char *theme);
+JSValueRef evaluate_source(JSContextRef ctx, char *type, char *source_value, bool expression, bool print_nil, char *set_ns, char *theme, bool block_until_ready);
 char *munge(char *s);
 
 void bootstrap(JSContextRef ctx, char *out_path);

--- a/planck-c/cljs.h
+++ b/planck-c/cljs.h
@@ -10,3 +10,5 @@ void run_main_in_ns(JSContextRef ctx, char *ns, int argc, char **argv);
 
 char *get_current_ns();
 char **get_completions(JSContextRef ctx, const char *buffer, int *num_completions);
+
+void cljs_engine_init(JSContextRef ctx);

--- a/planck-c/functions.c
+++ b/planck-c/functions.c
@@ -1,0 +1,383 @@
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#include <JavaScriptCore/JavaScript.h>
+
+#include "bundle.h"
+#include "globals.h"
+#include "io.h"
+#include "jsc_utils.h"
+#include "str.h"
+#include "zip.h"
+
+#define CONSOLE_LOG_BUF_SIZE 1000
+char console_log_buf[CONSOLE_LOG_BUF_SIZE];
+
+JSValueRef function_console_log(JSContextRef ctx, JSObjectRef function, JSObjectRef this_object,
+		size_t argc, const JSValueRef args[], JSValueRef* exception) {
+	for (int i = 0; i < argc; i++) {
+		if (i > 0) {
+			fprintf(stdout, " ");
+		}
+
+		JSStringRef str = to_string(ctx, args[i]);
+		JSStringGetUTF8CString(str, console_log_buf, CONSOLE_LOG_BUF_SIZE);
+		fprintf(stdout, "%s", console_log_buf);
+	}
+	fprintf(stdout, "\n");
+
+	return JSValueMakeUndefined(ctx);
+}
+
+JSValueRef function_console_error(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
+		size_t argc, const JSValueRef args[], JSValueRef* exception) {
+	for (int i = 0; i < argc; i++) {
+		if (i > 0) {
+			fprintf(stderr, " ");
+		}
+
+		JSStringRef str = to_string(ctx, args[i]);
+		JSStringGetUTF8CString(str, console_log_buf, CONSOLE_LOG_BUF_SIZE);
+		fprintf(stderr, "%s", console_log_buf);
+	}
+	fprintf(stderr, "\n");
+
+	return JSValueMakeUndefined(ctx);
+}
+
+JSValueRef function_read_file(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
+		size_t argc, const JSValueRef args[], JSValueRef* exception) {
+	// TODO: implement fully
+
+	if (argc == 1 && JSValueGetType(ctx, args[0]) == kJSTypeString) {
+		char path[100];
+		JSStringRef path_str = JSValueToStringCopy(ctx, args[0], NULL);
+		assert(JSStringGetLength(path_str) < 100);
+		JSStringGetUTF8CString(path_str, path, 100);
+		JSStringRelease(path_str);
+
+		// debug_print_value("read_file", ctx, args[0]);
+
+		time_t last_modified = 0;
+		char *contents = get_contents(path, &last_modified);
+		if (contents != NULL) {
+			JSStringRef contents_str = JSStringCreateWithUTF8CString(contents);
+			free(contents);
+
+			JSValueRef res[2];
+			res[0] = JSValueMakeString(ctx, contents_str);
+			res[1] = JSValueMakeNumber(ctx, last_modified);
+			return JSObjectMakeArray(ctx, 2, res, NULL);
+		}
+	}
+
+	return JSValueMakeNull(ctx);
+}
+
+JSValueRef function_load(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
+		size_t argc, const JSValueRef args[], JSValueRef* exception) {
+	// TODO: implement fully
+
+	if (argc == 1 && JSValueGetType(ctx, args[0]) == kJSTypeString) {
+		char path[100];
+		JSStringRef path_str = JSValueToStringCopy(ctx, args[0], NULL);
+		assert(JSStringGetLength(path_str) < 100);
+		JSStringGetUTF8CString(path_str, path, 100);
+		JSStringRelease(path_str);
+
+		// debug_print_value("load", ctx, args[0]);
+
+		time_t last_modified = 0;
+		char *contents = NULL;
+
+		bool developing = (config.num_src_paths == 1 &&
+		                   strcmp(config.src_paths[0].type, "src") == 0 &&
+		                   str_has_suffix(config.src_paths[0].path, "/planck-cljs/src/") == 0);
+
+		if (!developing) {
+			contents = bundle_get_contents(path);
+			last_modified = 0;
+		}
+
+		// load from classpath
+		if (contents == NULL) {
+			for (int i = 0; i < config.num_src_paths; i++) {
+				char *type = config.src_paths[i].type;
+				char *location = config.src_paths[i].path;
+
+				if (strcmp(type, "src") == 0) {
+					char *full_path = str_concat(location, path);
+					contents = get_contents(full_path, &last_modified);
+					free(full_path);
+				} else if (strcmp(type, "jar") == 0) {
+					contents = get_contents_zip(location, path, &last_modified);
+				}
+
+				if (contents != NULL) {
+					break;
+				}
+			}
+		}
+
+		// load from out/
+		if (contents == NULL) {
+			if (config.out_path != NULL) {
+				char *full_path = str_concat(config.out_path, path);
+				contents = get_contents(full_path, &last_modified);
+				free(full_path);
+			}
+		}
+
+		if (developing && contents == NULL) {
+			contents = bundle_get_contents(path);
+			last_modified = 0;
+		}
+
+		if (contents != NULL) {
+			JSStringRef contents_str = JSStringCreateWithUTF8CString(contents);
+			free(contents);
+
+			JSValueRef res[2];
+			res[0] = JSValueMakeString(ctx, contents_str);
+			res[1] = JSValueMakeNumber(ctx, last_modified);
+			return JSObjectMakeArray(ctx, 2, res, NULL);
+		}
+	}
+
+	return JSValueMakeNull(ctx);
+}
+
+JSValueRef function_load_deps_cljs_files(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
+		size_t argc, const JSValueRef args[], JSValueRef* exception) {
+	int num_files = 0;
+	char **deps_cljs_files = NULL;
+
+	if (argc == 0) {
+		for (int i = 0; i < config.num_src_paths; i++) {
+			char *type = config.src_paths[i].type;
+			char *location = config.src_paths[i].path;
+
+			if (strcmp(type, "jar") == 0) {
+				char *source = get_contents_zip(location, "deps.cljs", NULL);
+				if (source != NULL) {
+					num_files += 1;
+					deps_cljs_files = realloc(deps_cljs_files, num_files * sizeof(char*));
+					deps_cljs_files[num_files - 1] = source;
+				}
+			}
+		}
+	}
+
+	JSValueRef files[num_files];
+	for (int i = 0; i < num_files; i++) {
+		JSStringRef file = JSStringCreateWithUTF8CString(deps_cljs_files[i]);
+		files[i] = JSValueMakeString(ctx, file);
+		free(deps_cljs_files[i]);
+	}
+	free(deps_cljs_files);
+
+	return JSObjectMakeArray(ctx, num_files, files, NULL);
+}
+
+JSValueRef function_cache(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
+		size_t argc, const JSValueRef args[], JSValueRef* exception) {
+	if (argc == 4 &&
+			JSValueGetType (ctx, args[0]) == kJSTypeString &&
+			JSValueGetType (ctx, args[1]) == kJSTypeString &&
+			(JSValueGetType (ctx, args[2]) == kJSTypeString
+				|| JSValueGetType (ctx, args[2]) == kJSTypeNull) &&
+			(JSValueGetType (ctx, args[3]) == kJSTypeString
+				|| JSValueGetType (ctx, args[3]) == kJSTypeNull)) {
+		// debug_print_value("cache", ctx, args[0]);
+
+		char *cache_prefix = value_to_c_string(ctx, args[0]);
+		char *source = value_to_c_string(ctx, args[1]);
+		char *cache = value_to_c_string(ctx, args[2]);
+		char *sourcemap = value_to_c_string(ctx, args[3]);
+
+		char *suffix = NULL;
+		int max_suffix_len = 20;
+		int prefix_len = strlen(cache_prefix);
+		char *path = malloc((prefix_len + max_suffix_len) * sizeof(char));
+		memset(path, 0, prefix_len + max_suffix_len);
+
+		suffix = ".js";
+		strcpy(path, cache_prefix);
+		strcat(path, suffix);
+		write_contents(path, source);
+
+		suffix = ".cache.json";
+		strcpy(path, cache_prefix);
+		strcat(path, suffix);
+		write_contents(path, cache);
+
+		suffix = ".js.map.json";
+		strcpy(path, cache_prefix);
+		strcat(path, suffix);
+		write_contents(path, sourcemap);
+
+		free(cache_prefix);
+		free(source);
+		free(cache);
+		free(sourcemap);
+
+		free(path);
+	}
+
+	return  JSValueMakeNull(ctx);
+}
+
+JSValueRef function_eval(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
+		size_t argc, const JSValueRef args[], JSValueRef* exception) {
+	JSValueRef val = NULL;
+
+	if (argc == 2
+		&& JSValueGetType(ctx, args[0]) == kJSTypeString
+		&& JSValueGetType(ctx, args[1]) == kJSTypeString) {
+		// debug_print_value("eval", ctx, args[0]);
+
+		JSStringRef sourceRef = JSValueToStringCopy(ctx, args[0], NULL);
+		JSStringRef pathRef = JSValueToStringCopy(ctx, args[1], NULL);
+
+		JSEvaluateScript(ctx, sourceRef, NULL, pathRef, 0, &val);
+
+		JSStringRelease(pathRef);
+		JSStringRelease(sourceRef);
+	}
+
+	return val != NULL ? val : JSValueMakeNull(ctx);
+}
+
+JSValueRef function_get_term_size(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
+		size_t argc, const JSValueRef args[], JSValueRef* exception) {
+	// if (return_term_size)
+	struct winsize w;
+	ioctl(STDOUT_FILENO, TIOCGWINSZ, &w);
+	JSValueRef  arguments[2];
+	arguments[0] = JSValueMakeNumber(ctx, w.ws_row);
+	arguments[1] = JSValueMakeNumber(ctx, w.ws_col);
+	return JSObjectMakeArray(ctx, 2, arguments, NULL);
+	// return JSValueMakeNull(ctx);
+}
+
+JSValueRef function_print_fn(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
+		size_t argc, const JSValueRef args[], JSValueRef* exception) {
+	if (argc == 1 && JSValueIsString(ctx, args[0])) {
+		char *str = value_to_c_string(ctx, args[0]);
+
+		fprintf(stdout, "%s", str);
+		fflush(stdout);
+
+		free(str);
+	}
+
+	return JSValueMakeNull(ctx);
+}
+
+JSValueRef function_print_err_fn(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
+		size_t argc, const JSValueRef args[], JSValueRef* exception) {
+	if (argc == 1 && JSValueIsString(ctx, args[0])) {
+		char *str = value_to_c_string(ctx, args[0]);
+
+		fprintf(stderr, "%s", str);
+		fflush(stderr);
+
+		free(str);
+	}
+
+	return JSValueMakeNull(ctx);
+}
+
+JSValueRef function_set_exit_value(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
+		size_t argc, const JSValueRef args[], JSValueRef* exception) {
+	if (argc == 1 && JSValueGetType (ctx, args[0]) == kJSTypeNumber) {
+		exit_value = JSValueToNumber(ctx, args[0], NULL);
+	}
+	return JSValueMakeNull(ctx);
+}
+
+JSValueRef function_raw_read_stdin(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
+		size_t argc, const JSValueRef args[], JSValueRef* exception) {
+	char buf[1024 + 1];
+
+	int n = fread(buf, 1, config.is_tty ? 1 : 1024, stdin);
+	if (n > 0) {
+		buf[n] = '\0';
+		return c_string_to_value(ctx, buf);
+	}
+
+	return JSValueMakeNull(ctx);
+}
+
+JSValueRef function_raw_write_stdout(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
+		size_t argc, const JSValueRef args[], JSValueRef* exception) {
+	if (argc == 1 && JSValueGetType(ctx, args[0]) == kJSTypeString) {
+		char *s = value_to_c_string(ctx, args[0]);
+		fprintf(stdout, "%s", s);
+		free(s);
+	}
+
+	return JSValueMakeNull(ctx);
+}
+
+JSValueRef function_raw_flush_stdout(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
+		size_t argc, const JSValueRef args[], JSValueRef* exception) {
+	fflush(stdout);
+
+	return JSValueMakeNull(ctx);
+}
+
+JSValueRef function_raw_write_stderr(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
+		size_t argc, const JSValueRef args[], JSValueRef* exception) {
+	if (argc == 1 && JSValueGetType(ctx, args[0]) == kJSTypeString) {
+		char *s = value_to_c_string(ctx, args[0]);
+		fprintf(stderr, "%s", s);
+		free(s);
+	}
+
+	return JSValueMakeNull(ctx);
+}
+
+JSValueRef function_raw_flush_stderr(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
+		size_t argc, const JSValueRef args[], JSValueRef* exception) {
+	fflush(stderr);
+
+	return JSValueMakeNull(ctx);
+}
+
+JSValueRef function_import_script(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
+		size_t argc, const JSValueRef args[], JSValueRef* exception) {
+	if (argc == 1 && JSValueGetType(ctx, args[0]) == kJSTypeString) {
+		JSStringRef path_str_ref = JSValueToStringCopy(ctx, args[0], NULL);
+		assert(JSStringGetLength(path_str_ref) < 100);
+		char tmp[100];
+		tmp[0] = '\0';
+		JSStringGetUTF8CString(path_str_ref, tmp, 100);
+		JSStringRelease(path_str_ref);
+
+		char *path = tmp;
+		if (str_has_prefix(path, "goog/../") == 0) {
+			path = path + 8;
+		}
+
+		char *source = NULL;
+		if (config.out_path == NULL) {
+			source = bundle_get_contents(path);
+		} else {
+			char *full_path = str_concat(config.out_path, path);
+			source = get_contents(full_path, NULL);
+			free(full_path);
+		}
+
+		if (source != NULL) {
+			evaluate_script(ctx, source, path);
+			free(source);
+		}
+	}
+
+	return JSValueMakeUndefined(ctx);
+}

--- a/planck-c/functions.h
+++ b/planck-c/functions.h
@@ -1,0 +1,24 @@
+JSValueRef function_console_log(JSContextRef ctx, JSObjectRef function, JSObjectRef this_object, size_t argc, const JSValueRef args[], JSValueRef* exception);
+JSValueRef function_console_error(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argc, const JSValueRef args[], JSValueRef* exception);
+
+JSValueRef function_read_file(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argc, const JSValueRef args[], JSValueRef* exception);
+JSValueRef function_load(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,	size_t argc, const JSValueRef args[], JSValueRef* exception);
+JSValueRef function_load_deps_cljs_files(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,	size_t argc, const JSValueRef args[], JSValueRef* exception);
+JSValueRef function_cache(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,	size_t argc, const JSValueRef args[], JSValueRef* exception);
+
+JSValueRef function_eval(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,	size_t argc, const JSValueRef args[], JSValueRef* exception);
+
+JSValueRef function_get_term_size(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argc, const JSValueRef args[], JSValueRef* exception);
+
+JSValueRef function_print_fn(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argc, const JSValueRef args[], JSValueRef* exception);
+JSValueRef function_print_err_fn(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argc, const JSValueRef args[], JSValueRef* exception);
+
+JSValueRef function_set_exit_value(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argc, const JSValueRef args[], JSValueRef* exception);
+
+JSValueRef function_raw_read_stdin(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argc, const JSValueRef args[], JSValueRef* exception);
+JSValueRef function_raw_write_stdout(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argc, const JSValueRef args[], JSValueRef* exception);
+JSValueRef function_raw_flush_stdout(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argc, const JSValueRef args[], JSValueRef* exception);
+JSValueRef function_raw_write_stderr(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argc, const JSValueRef args[], JSValueRef* exception);
+JSValueRef function_raw_flush_stderr(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argc, const JSValueRef args[], JSValueRef* exception);
+
+JSValueRef function_import_script(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argc, const JSValueRef args[], JSValueRef* exception);

--- a/planck-c/globals.h
+++ b/planck-c/globals.h
@@ -1,0 +1,45 @@
+// Global variables used throughout Planck
+
+#define PLANCK_VERSION "2.0"
+
+// Configuration
+
+struct src_path {
+	char *type;
+	char *path;
+};
+
+struct script {
+	char *type;
+	bool expression;
+	char *source;
+};
+
+struct config {
+	bool verbose;
+	bool quiet;
+	bool is_tty;
+	bool repl;
+	bool javascript;
+	bool static_fns;
+	bool elide_asserts;
+	char *theme;
+
+	char *main_ns_name;
+	int num_rest_args;
+	char **rest_args;
+
+	char *out_path;
+	char *cache_path;
+
+	int num_src_paths;
+	struct src_path *src_paths;
+	int num_scripts;
+	struct script *scripts;
+};
+
+extern struct config config;
+
+// Mutable variables
+
+extern int exit_value;

--- a/planck-c/jsc_utils.c
+++ b/planck-c/jsc_utils.c
@@ -4,6 +4,8 @@
 
 #include <JavaScriptCore/JavaScript.h>
 
+#include "jsc_utils.h"
+
 JSStringRef to_string(JSContextRef ctx, JSValueRef val) {
 	if (JSValueIsUndefined(ctx, val)) {
 		return JSStringCreateWithUTF8CString("undefined");
@@ -17,6 +19,15 @@ JSStringRef to_string(JSContextRef ctx, JSValueRef val) {
 		JSValueRef obj_val = JSObjectCallAsFunction(ctx, to_string_obj, obj, 0, NULL, NULL);
 
 		return JSValueToStringCopy(ctx, obj_val, NULL);
+	}
+}
+
+void print_value(char *prefix, JSContextRef ctx, JSValueRef val) {
+	if (val != NULL) {
+		JSStringRef str = to_string(ctx, val);
+		char *ex_str = value_to_c_string(ctx, JSValueMakeString(ctx, str));
+		printf("%s%s\n", prefix, ex_str);
+		free(ex_str);
 	}
 }
 

--- a/planck-c/jsc_utils.h
+++ b/planck-c/jsc_utils.h
@@ -1,6 +1,15 @@
 #include <JavaScriptCore/JavaScript.h>
 
 JSStringRef to_string(JSContextRef ctx, JSValueRef val);
+
+#ifdef DEBUG
+#define debug_print_value(prefix, ctx, val)	print_value(prefix ": ", ctx, val)
+#else
+#define debug_print_value(prefix, ctx, val)
+#endif
+
+void print_value(char *prefix, JSContextRef ctx, JSValueRef val);
+
 JSValueRef evaluate_script(JSContextRef ctx, char *script, char *source);
 
 char *value_to_c_string(JSContextRef ctx, JSValueRef val);

--- a/planck-c/main.c
+++ b/planck-c/main.c
@@ -6,7 +6,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <time.h>
 #include <unistd.h>
@@ -17,418 +16,14 @@
 
 #include "bundle.h"
 #include "cljs.h"
-#include "http.h"
+#include "globals.h"
 #include "io.h"
 #include "jsc_utils.h"
 #include "legal.h"
 #include "str.h"
 #include "zip.h"
 
-#define PLANCK_VERSION "2.0"
-
-#define CONSOLE_LOG_BUF_SIZE 1000
-char console_log_buf[CONSOLE_LOG_BUF_SIZE];
-
-bool is_tty = false;
-int exit_value = 0;
-struct src_path {
-	char *type;
-	char *path;
-};
-struct src_path *src_paths = NULL;
-int num_src_paths = 0;
-char *out_path = NULL;
-
 void completion(const char *buf, linenoiseCompletions *lc);
-
-#ifdef DEBUG
-#define debug_print_value(prefix, ctx, val)	print_value(prefix ": ", ctx, val)
-#else
-#define debug_print_value(prefix, ctx, val)
-#endif
-
-void print_value(char *prefix, JSContextRef ctx, JSValueRef val) {
-	if (val != NULL) {
-		JSStringRef str = to_string(ctx, val);
-		char *ex_str = value_to_c_string(ctx, JSValueMakeString(ctx, str));
-		printf("%s%s\n", prefix, ex_str);
-		free(ex_str);
-	}
-}
-
-JSValueRef function_console_log(JSContextRef ctx, JSObjectRef function, JSObjectRef this_object,
-		size_t argc, const JSValueRef args[], JSValueRef* exception) {
-	for (int i = 0; i < argc; i++) {
-		if (i > 0) {
-			fprintf(stdout, " ");
-		}
-
-		JSStringRef str = to_string(ctx, args[i]);
-		JSStringGetUTF8CString(str, console_log_buf, CONSOLE_LOG_BUF_SIZE);
-		fprintf(stdout, "%s", console_log_buf);
-	}
-	fprintf(stdout, "\n");
-
-	return JSValueMakeUndefined(ctx);
-}
-
-JSValueRef function_console_error(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
-		size_t argc, const JSValueRef args[], JSValueRef* exception) {
-	for (int i = 0; i < argc; i++) {
-		if (i > 0) {
-			fprintf(stderr, " ");
-		}
-
-		JSStringRef str = to_string(ctx, args[i]);
-		JSStringGetUTF8CString(str, console_log_buf, CONSOLE_LOG_BUF_SIZE);
-		fprintf(stderr, "%s", console_log_buf);
-	}
-	fprintf(stderr, "\n");
-
-	return JSValueMakeUndefined(ctx);
-}
-
-JSValueRef function_read_file(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
-		size_t argc, const JSValueRef args[], JSValueRef* exception) {
-	// TODO: implement fully
-
-	if (argc == 1 && JSValueGetType(ctx, args[0]) == kJSTypeString) {
-		char path[100];
-		JSStringRef path_str = JSValueToStringCopy(ctx, args[0], NULL);
-		assert(JSStringGetLength(path_str) < 100);
-		JSStringGetUTF8CString(path_str, path, 100);
-		JSStringRelease(path_str);
-
-		// debug_print_value("read_file", ctx, args[0]);
-
-		time_t last_modified = 0;
-		char *contents = get_contents(path, &last_modified);
-		if (contents != NULL) {
-			JSStringRef contents_str = JSStringCreateWithUTF8CString(contents);
-			free(contents);
-
-			JSValueRef res[2];
-			res[0] = JSValueMakeString(ctx, contents_str);
-			res[1] = JSValueMakeNumber(ctx, last_modified);
-			return JSObjectMakeArray(ctx, 2, res, NULL);
-		}
-	}
-
-	return JSValueMakeNull(ctx);
-}
-
-JSValueRef function_load(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
-		size_t argc, const JSValueRef args[], JSValueRef* exception) {
-	// TODO: implement fully
-
-	if (argc == 1 && JSValueGetType(ctx, args[0]) == kJSTypeString) {
-		char path[100];
-		JSStringRef path_str = JSValueToStringCopy(ctx, args[0], NULL);
-		assert(JSStringGetLength(path_str) < 100);
-		JSStringGetUTF8CString(path_str, path, 100);
-		JSStringRelease(path_str);
-
-		// debug_print_value("load", ctx, args[0]);
-
-		time_t last_modified = 0;
-		char *contents = NULL;
-
-		bool developing = (num_src_paths == 1 &&
-		                   strcmp(src_paths[0].type, "src") == 0 &&
-		                   str_has_suffix(src_paths[0].path, "/planck-cljs/src/") == 0);
-
-		if (!developing) {
-			contents = bundle_get_contents(path);
-			last_modified = 0;
-		}
-
-		// load from classpath
-		if (contents == NULL) {
-			for (int i = 0; i < num_src_paths; i++) {
-				char *type = src_paths[i].type;
-				char *location = src_paths[i].path;
-
-				if (strcmp(type, "src") == 0) {
-					char *full_path = str_concat(location, path);
-					contents = get_contents(full_path, &last_modified);
-					free(full_path);
-				} else if (strcmp(type, "jar") == 0) {
-					contents = get_contents_zip(location, path, &last_modified);
-				}
-
-				if (contents != NULL) {
-					break;
-				}
-			}
-		}
-
-		// load from out/
-		if (contents == NULL) {
-			if (out_path != NULL) {
-				char *full_path = str_concat(out_path, path);
-				contents = get_contents(full_path, &last_modified);
-				free(full_path);
-			}
-		}
-
-		if (developing && contents == NULL) {
-			contents = bundle_get_contents(path);
-			last_modified = 0;
-		}
-
-		if (contents != NULL) {
-			JSStringRef contents_str = JSStringCreateWithUTF8CString(contents);
-			free(contents);
-
-			JSValueRef res[2];
-			res[0] = JSValueMakeString(ctx, contents_str);
-			res[1] = JSValueMakeNumber(ctx, last_modified);
-			return JSObjectMakeArray(ctx, 2, res, NULL);
-		}
-	}
-
-	return JSValueMakeNull(ctx);
-}
-
-JSValueRef function_load_deps_cljs_files(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
-		size_t argc, const JSValueRef args[], JSValueRef* exception) {
-	int num_files = 0;
-	char **deps_cljs_files = NULL;
-
-	if (argc == 0) {
-		for (int i = 0; i < num_src_paths; i++) {
-			char *type = src_paths[i].type;
-			char *location = src_paths[i].path;
-
-			if (strcmp(type, "jar") == 0) {
-				char *source = get_contents_zip(location, "deps.cljs", NULL);
-				if (source != NULL) {
-					num_files += 1;
-					deps_cljs_files = realloc(deps_cljs_files, num_files * sizeof(char*));
-					deps_cljs_files[num_files - 1] = source;
-				}
-			}
-		}
-	}
-
-	JSValueRef files[num_files];
-	for (int i = 0; i < num_files; i++) {
-		JSStringRef file = JSStringCreateWithUTF8CString(deps_cljs_files[i]);
-		files[i] = JSValueMakeString(ctx, file);
-		free(deps_cljs_files[i]);
-	}
-	free(deps_cljs_files);
-
-	return JSObjectMakeArray(ctx, num_files, files, NULL);
-}
-
-JSValueRef function_cache(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
-		size_t argc, const JSValueRef args[], JSValueRef* exception) {
-	if (argc == 4 &&
-			JSValueGetType (ctx, args[0]) == kJSTypeString &&
-			JSValueGetType (ctx, args[1]) == kJSTypeString &&
-			(JSValueGetType (ctx, args[2]) == kJSTypeString
-				|| JSValueGetType (ctx, args[2]) == kJSTypeNull) &&
-			(JSValueGetType (ctx, args[3]) == kJSTypeString
-				|| JSValueGetType (ctx, args[3]) == kJSTypeNull)) {
-		// debug_print_value("cache", ctx, args[0]);
-
-		char *cache_prefix = value_to_c_string(ctx, args[0]);
-		char *source = value_to_c_string(ctx, args[1]);
-		char *cache = value_to_c_string(ctx, args[2]);
-		char *sourcemap = value_to_c_string(ctx, args[3]);
-
-		char *suffix = NULL;
-		int max_suffix_len = 20;
-		int prefix_len = strlen(cache_prefix);
-		char *path = malloc((prefix_len + max_suffix_len) * sizeof(char));
-		memset(path, 0, prefix_len + max_suffix_len);
-
-		suffix = ".js";
-		strcpy(path, cache_prefix);
-		strcat(path, suffix);
-		write_contents(path, source);
-
-		suffix = ".cache.json";
-		strcpy(path, cache_prefix);
-		strcat(path, suffix);
-		write_contents(path, cache);
-
-		suffix = ".js.map.json";
-		strcpy(path, cache_prefix);
-		strcat(path, suffix);
-		write_contents(path, sourcemap);
-
-		free(cache_prefix);
-		free(source);
-		free(cache);
-		free(sourcemap);
-
-		free(path);
-	}
-
-	return  JSValueMakeNull(ctx);
-}
-
-JSValueRef function_eval(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
-		size_t argc, const JSValueRef args[], JSValueRef* exception) {
-	JSValueRef val = NULL;
-
-	if (argc == 2
-		&& JSValueGetType(ctx, args[0]) == kJSTypeString
-		&& JSValueGetType(ctx, args[1]) == kJSTypeString) {
-		// debug_print_value("eval", ctx, args[0]);
-
-		JSStringRef sourceRef = JSValueToStringCopy(ctx, args[0], NULL);
-		JSStringRef pathRef = JSValueToStringCopy(ctx, args[1], NULL);
-
-		JSEvaluateScript(ctx, sourceRef, NULL, pathRef, 0, &val);
-
-		JSStringRelease(pathRef);
-		JSStringRelease(sourceRef);
-	}
-
-	return val != NULL ? val : JSValueMakeNull(ctx);
-}
-
-JSValueRef function_get_term_size(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
-		size_t argc, const JSValueRef args[], JSValueRef* exception) {
-	// if (return_term_size)
-	struct winsize w;
-	ioctl(STDOUT_FILENO, TIOCGWINSZ, &w);
-	JSValueRef  arguments[2];
-	arguments[0] = JSValueMakeNumber(ctx, w.ws_row);
-	arguments[1] = JSValueMakeNumber(ctx, w.ws_col);
-	return JSObjectMakeArray(ctx, 2, arguments, NULL);
-	// return JSValueMakeNull(ctx);
-}
-
-JSValueRef function_print_fn(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
-		size_t argc, const JSValueRef args[], JSValueRef* exception) {
-	if (argc == 1 && JSValueIsString(ctx, args[0])) {
-		char *str = value_to_c_string(ctx, args[0]);
-
-		fprintf(stdout, "%s", str);
-		fflush(stdout);
-
-		free(str);
-	}
-
-	return JSValueMakeNull(ctx);
-}
-
-JSValueRef function_print_err_fn(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
-		size_t argc, const JSValueRef args[], JSValueRef* exception) {
-	if (argc == 1 && JSValueIsString(ctx, args[0])) {
-		char *str = value_to_c_string(ctx, args[0]);
-
-		fprintf(stderr, "%s", str);
-		fflush(stderr);
-
-		free(str);
-	}
-
-	return JSValueMakeNull(ctx);
-}
-
-JSValueRef function_set_exit_value(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
-		size_t argc, const JSValueRef args[], JSValueRef* exception) {
-	if (argc == 1 && JSValueGetType (ctx, args[0]) == kJSTypeNumber) {
-		exit_value = JSValueToNumber(ctx, args[0], NULL);
-	}
-	return JSValueMakeNull(ctx);
-}
-
-JSValueRef function_raw_read_stdin(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
-		size_t argc, const JSValueRef args[], JSValueRef* exception) {
-	char buf[1024 + 1];
-
-	int n = fread(buf, 1, is_tty ? 1 : 1024, stdin);
-	if (n > 0) {
-		buf[n] = '\0';
-		return c_string_to_value(ctx, buf);
-	}
-
-	return JSValueMakeNull(ctx);
-}
-
-JSValueRef function_raw_write_stdout(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
-		size_t argc, const JSValueRef args[], JSValueRef* exception) {
-	if (argc == 1 && JSValueGetType(ctx, args[0]) == kJSTypeString) {
-		char *s = value_to_c_string(ctx, args[0]);
-		fprintf(stdout, "%s", s);
-		free(s);
-	}
-
-	return JSValueMakeNull(ctx);
-}
-
-JSValueRef function_raw_flush_stdout(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
-		size_t argc, const JSValueRef args[], JSValueRef* exception) {
-	fflush(stdout);
-
-	return JSValueMakeNull(ctx);
-}
-
-JSValueRef function_raw_write_stderr(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
-		size_t argc, const JSValueRef args[], JSValueRef* exception) {
-	if (argc == 1 && JSValueGetType(ctx, args[0]) == kJSTypeString) {
-		char *s = value_to_c_string(ctx, args[0]);
-		fprintf(stderr, "%s", s);
-		free(s);
-	}
-
-	return JSValueMakeNull(ctx);
-}
-
-JSValueRef function_raw_flush_stderr(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
-		size_t argc, const JSValueRef args[], JSValueRef* exception) {
-	fflush(stderr);
-
-	return JSValueMakeNull(ctx);
-}
-
-JSValueRef function_import_script(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
-		size_t argc, const JSValueRef args[], JSValueRef* exception) {
-	if (argc == 1 && JSValueGetType(ctx, args[0]) == kJSTypeString) {
-		JSStringRef path_str_ref = JSValueToStringCopy(ctx, args[0], NULL);
-		assert(JSStringGetLength(path_str_ref) < 100);
-		char tmp[100];
-		tmp[0] = '\0';
-		JSStringGetUTF8CString(path_str_ref, tmp, 100);
-		JSStringRelease(path_str_ref);
-
-		char *path = tmp;
-		if (str_has_prefix(path, "goog/../") == 0) {
-			path = path + 8;
-		}
-
-		char *source = NULL;
-		if (out_path == NULL) {
-			source = bundle_get_contents(path);
-		} else {
-			char *full_path = str_concat(out_path, path);
-			source = get_contents(full_path, NULL);
-			free(full_path);
-		}
-
-		if (source != NULL) {
-			evaluate_script(ctx, source, path);
-			free(source);
-		}
-	}
-
-	return JSValueMakeUndefined(ctx);
-}
-
-void register_global_function(JSContextRef ctx, char *name, JSObjectCallAsFunctionCallback handler) {
-	JSObjectRef global_obj = JSContextGetGlobalObject(ctx);
-
-	JSStringRef fn_name = JSStringCreateWithUTF8CString(name);
-	JSObjectRef fn_obj = JSObjectMakeFunctionWithCallback(ctx, fn_name, handler);
-
-	JSObjectSetProperty(ctx, global_obj, fn_name, fn_obj, kJSPropertyAttributeNone, NULL);
-}
 
 void usage(char *program_name) {
 	printf("Planck %s\n", PLANCK_VERSION);
@@ -505,28 +100,27 @@ void banner() {
 	printf("\n");
 }
 
-bool verbose = false;
-bool quiet = false;
-bool repl = false;
-bool static_fns = false;
-bool elide_asserts = false;
-char *cache_path = NULL;
-char *theme = "light";
-char *main_ns_name = NULL;
-
-bool javascript = false;
-
+struct config config;
+int exit_value;
 JSContextRef global_ctx = NULL;
 
-struct script {
-	char *type;
-	bool expression;
-	char *source;
-};
-struct script *scripts = NULL;
-int num_scripts = 0;
-
 int main(int argc, char **argv) {
+	config.verbose = false;
+	config.quiet = false;
+	config.repl = false;
+	config.static_fns = false;
+	config.elide_asserts = false;
+	config.cache_path = NULL;
+	config.theme = "light";
+
+	config.out_path = NULL;
+	config.num_src_paths = 0;
+	config.src_paths = NULL;
+	config.num_scripts = 0;
+	config.scripts = NULL;
+
+	config.main_ns_name = NULL;
+
 	struct option long_options[] = {
 		{"help", no_argument, NULL, 'h'},
 		{"legal", no_argument, NULL, 'l'},
@@ -559,55 +153,55 @@ int main(int argc, char **argv) {
 			legal();
 			return 0;
 		case 'v':
-			verbose = true;
+			config.verbose = true;
 			break;
 		case 'q':
-			quiet = true;
+			config.quiet = true;
 			break;
 		case 'r':
-			repl = true;
+			config.repl = true;
 			break;
 		case 's':
-			static_fns = true;
+			config.static_fns = true;
 			break;
 		case 'a':
-			elide_asserts = true;
+			config.elide_asserts = true;
 			break;
 		case 'k':
-			cache_path = argv[optind - 1];
+			config.cache_path = argv[optind - 1];
 			break;
 		case 'K':
-			cache_path = ".planck_cache";
+			config.cache_path = ".planck_cache";
 			{
-				char *path_copy = strdup(cache_path);
+				char *path_copy = strdup(config.cache_path);
 				char *dir = dirname(path_copy);
 				if (mkdir_p(dir) < 0) {
-					fprintf(stderr, "Could not create %s: %s\n", cache_path, strerror(errno));
+					fprintf(stderr, "Could not create %s: %s\n", config.cache_path, strerror(errno));
 				}
 				free(path_copy);
 			}
 			break;
 		case 'j':
-			javascript = true;
+			config.javascript = true;
 			break;
 		case 'e':
-			num_scripts += 1;
-			scripts = realloc(scripts, num_scripts * sizeof(struct script));
-			scripts[num_scripts - 1].type = "text";
-			scripts[num_scripts - 1].expression = true;
-			scripts[num_scripts - 1].source = argv[optind - 1];
+			config.num_scripts += 1;
+			config.scripts = realloc(config.scripts, config.num_scripts * sizeof(struct script));
+			config.scripts[config.num_scripts - 1].type = "text";
+			config.scripts[config.num_scripts - 1].expression = true;
+			config.scripts[config.num_scripts - 1].source = argv[optind - 1];
 			break;
 		case 'i':
-			num_scripts += 1;
-			scripts = realloc(scripts, num_scripts * sizeof(struct script));
-			scripts[num_scripts - 1].type = "path";
-			scripts[num_scripts - 1].expression = false;
-			scripts[num_scripts - 1].source = argv[optind - 1];
+			config.num_scripts += 1;
+			config.scripts = realloc(config.scripts, config.num_scripts * sizeof(struct script));
+			config.scripts[config.num_scripts - 1].type = "path";
+			config.scripts[config.num_scripts - 1].expression = false;
+			config.scripts[config.num_scripts - 1].source = argv[optind - 1];
 			break;
 		case 'm':
-			main_ns_name = argv[optind - 1];
+			config.main_ns_name = argv[optind - 1];
 		case 't':
-			theme = argv[optind - 1];
+			config.theme = argv[optind - 1];
 			break;
 		case 'c':
 			{
@@ -619,10 +213,10 @@ int main(int argc, char **argv) {
 						type = "jar";
 					}
 
-					num_src_paths += 1;
-					src_paths = realloc(src_paths, num_src_paths * sizeof(struct src_path));
-					src_paths[num_src_paths - 1].type = type;
-					src_paths[num_src_paths - 1].path = strdup(source);
+					config.num_src_paths += 1;
+					config.src_paths = realloc(config.src_paths, config.num_src_paths * sizeof(struct src_path));
+					config.src_paths[config.num_src_paths - 1].type = type;
+					config.src_paths[config.num_src_paths - 1].path = strdup(source);
 
 					source = strtok(NULL, ":");
 				}
@@ -630,7 +224,7 @@ int main(int argc, char **argv) {
 				break;
 			}
 		case 'o':
-			out_path = argv[optind - 1];
+			config.out_path = argv[optind - 1];
 			break;
 		case '?':
 			usage(argv[0]);
@@ -640,131 +234,45 @@ int main(int argc, char **argv) {
 		}
 	}
 
-	int num_rest_args = 0;
-	char **rest_args = NULL;
+	config.num_rest_args = 0;
+	config.rest_args = NULL;
 	if (optind < argc) {
-		num_rest_args = argc - optind;
-		rest_args = malloc((argc - optind) * sizeof(char*));
+		config.num_rest_args = argc - optind;
+		config.rest_args = malloc((argc - optind) * sizeof(char*));
 		int i = 0;
 		while (optind < argc) {
-			rest_args[i++] = argv[optind++];
+			config.rest_args[i++] = argv[optind++];
 		}
 	}
 
-	if (num_scripts == 0 && main_ns_name == NULL && num_rest_args == 0) {
-		repl = true;
+	if (config.num_scripts == 0 && config.main_ns_name == NULL && config.num_rest_args == 0) {
+		config.repl = true;
 	}
 
-	if (main_ns_name != NULL && repl) {
+	if (config.main_ns_name != NULL && config.repl) {
 		printf("Only one main-opt can be specified.");
 	}
 
+	config.is_tty = isatty(STDIN_FILENO) == 1;
+
 	JSGlobalContextRef ctx = JSGlobalContextCreate(NULL);
 	global_ctx = ctx;
-
-	JSStringRef nameRef = JSStringCreateWithUTF8CString("planck");
-	JSGlobalContextSetName(ctx, nameRef);
-
-	evaluate_script(ctx, "var global = this;", "<init>");
-
-	register_global_function(ctx, "AMBLY_IMPORT_SCRIPT", function_import_script);
-	bootstrap(ctx, out_path);
-
-	register_global_function(ctx, "PLANCK_CONSOLE_LOG", function_console_log);
-	register_global_function(ctx, "PLANCK_CONSOLE_ERROR", function_console_error);
-
-	evaluate_script(ctx, "var console = {};"\
-			"console.log = PLANCK_CONSOLE_LOG;"\
-			"console.error = PLANCK_CONSOLE_ERROR;", "<init>");
-
-	evaluate_script(ctx, "var PLANCK_VERSION = \"" PLANCK_VERSION "\";", "<init>");
-
-	// require app namespaces
-	evaluate_script(ctx, "goog.require('planck.repl');", "<init>");
-
-	// without this things won't work
-	evaluate_script(ctx, "var window = global;", "<init>");
-
-	register_global_function(ctx, "PLANCK_READ_FILE", function_read_file);
-	register_global_function(ctx, "PLANCK_LOAD", function_load);
-	register_global_function(ctx, "PLANCK_LOAD_DEPS_CLJS_FILES", function_load_deps_cljs_files);
-	register_global_function(ctx, "PLANCK_CACHE", function_cache);
-
-	register_global_function(ctx, "PLANCK_EVAL", function_eval);
-
-	register_global_function(ctx, "PLANCK_GET_TERM_SIZE", function_get_term_size);
-	register_global_function(ctx, "PLANCK_PRINT_FN", function_print_fn);
-	register_global_function(ctx, "PLANCK_PRINT_ERR_FN", function_print_err_fn);
-
-	register_global_function(ctx, "PLANCK_SET_EXIT_VALUE", function_set_exit_value);
-
-	is_tty = isatty(STDIN_FILENO) == 1;
-	register_global_function(ctx, "PLANCK_RAW_READ_STDIN", function_raw_read_stdin);
-	register_global_function(ctx, "PLANCK_RAW_WRITE_STDOUT", function_raw_write_stdout);
-	register_global_function(ctx, "PLANCK_RAW_FLUSH_STDOUT", function_raw_flush_stdout);
-	register_global_function(ctx, "PLANCK_RAW_WRITE_STDERR", function_raw_write_stderr);
-	register_global_function(ctx, "PLANCK_RAW_FLUSH_STDERR", function_raw_flush_stderr);
-
-	register_global_function(ctx, "PLANCK_REQUEST", function_http_request);
-
-	{
-		JSValueRef arguments[num_rest_args];
-		for (int i = 0; i < num_rest_args; i++) {
-			arguments[i] = c_string_to_value(ctx, rest_args[i]);
-		}
-		JSValueRef args_ref = JSObjectMakeArray(ctx, num_rest_args, arguments, NULL);
-
-		JSValueRef global_obj = JSContextGetGlobalObject(ctx);
-		JSStringRef prop = JSStringCreateWithUTF8CString("PLANCK_INITIAL_COMMAND_LINE_ARGS");
-		JSObjectSetProperty(ctx, JSValueToObject(ctx, global_obj, NULL), prop, args_ref, kJSPropertyAttributeNone, NULL);
-		JSStringRelease(prop);
-	}
-
-	evaluate_script(ctx, "cljs.core.set_print_fn_BANG_.call(null,PLANCK_PRINT_FN);", "<init>");
-	evaluate_script(ctx, "cljs.core.set_print_err_fn_BANG_.call(null,PLANCK_PRINT_ERR_FN);", "<init>");
-
-	char *elide_script = str_concat("cljs.core._STAR_assert_STAR_ = ", elide_asserts ? "false" : "true");
-	evaluate_script(ctx, elide_script, "<init>");
-	free(elide_script);
-
-	{
-		JSValueRef arguments[4];
-		arguments[0] = JSValueMakeBoolean(ctx, repl);
-		arguments[1] = JSValueMakeBoolean(ctx, verbose);
-		JSValueRef cache_path_ref = NULL;
-		if (cache_path != NULL) {
-			JSStringRef cache_path_str = JSStringCreateWithUTF8CString(cache_path);
-			cache_path_ref = JSValueMakeString(ctx, cache_path_str);
-		}
-		arguments[2] = cache_path_ref;
-		arguments[3] = JSValueMakeBoolean(ctx, static_fns);
-		JSValueRef ex = NULL;
-		JSObjectCallAsFunction(ctx, get_function(ctx, "planck.repl", "init"), JSContextGetGlobalObject(ctx), 4, arguments, &ex);
-		debug_print_value("planck.repl/init", ctx, ex);
-	}
-
-	if (repl) {
-		evaluate_source(ctx, "text", "(require '[planck.repl :refer-macros [apropos dir find-doc doc source pst]])", true, false, "cljs.user", "dumb");
-	}
-
-	evaluate_script(ctx, "goog.provide('cljs.user');", "<init>");
-	evaluate_script(ctx, "goog.require('cljs.core');", "<init>");
-
-	evaluate_script(ctx, "cljs.core._STAR_assert_STAR_ = true;", "<init>");
+	cljs_engine_init(ctx);
 
 	// Process init arguments
 
-	for (int i = 0; i < num_scripts; i++) {
+	for (int i = 0; i < config.num_scripts; i++) {
 		// TODO: exit if not successfull
-		evaluate_source(ctx, scripts[i].type, scripts[i].source, scripts[i].expression, false, NULL, theme);
+		struct script script = config.scripts[i];
+		evaluate_source(ctx, script.type, script.source, script.expression, false, NULL, config.theme);
 	}
 
 	// Process main arguments
 
-	if (main_ns_name != NULL) {
-		run_main_in_ns(ctx, main_ns_name, num_rest_args, rest_args);
-	} else if (!repl && num_rest_args > 0) {
-		char *path = rest_args[0];
+	if (config.main_ns_name != NULL) {
+		run_main_in_ns(ctx, config.main_ns_name, config.num_rest_args, config.rest_args);
+	} else if (!config.repl && config.num_rest_args > 0) {
+		char *path = config.rest_args[0];
 
 		struct script script;
 		if (strcmp(path, "-") == 0) {
@@ -778,9 +286,9 @@ int main(int argc, char **argv) {
 			script.expression = false;
 		}
 
-		evaluate_source(ctx, script.type, script.source, script.expression, false, NULL, theme);
-	} else if (repl) {
-		if (!quiet) {
+		evaluate_source(ctx, script.type, script.source, script.expression, false, NULL, config.theme);
+	} else if (config.repl) {
+		if (!config.quiet) {
 			banner();
 		}
 
@@ -795,23 +303,23 @@ int main(int argc, char **argv) {
 			linenoiseHistoryLoad(history_path);
 		}
 
-		if (!javascript) {
+		if (!config.javascript) {
 			linenoiseSetCompletionCallback(completion);
 		}
 
-		char *prompt = javascript ? " > " : "cljs.user=> ";
-		char *current_ns = get_current_ns(ctx);
-		if (!javascript) {
+		char *prompt = config.javascript ? " > " : "cljs.user=> ";
+		char *current_ns = strdup("cljs.user");
+		if (!config.javascript) {
 			prompt = str_concat(current_ns, "=> ");
 		}
 
 		char *line;
 		while ((line = linenoise(prompt, "\x1b[36m", 0)) != NULL) {
-			if (javascript) {
+			if (config.javascript) {
 				JSValueRef res = evaluate_script(ctx, line, "<stdin>");
 				print_value("", ctx, res);
 			} else {
-				evaluate_source(ctx, "text", line, true, true, current_ns, theme);
+				evaluate_source(ctx, "text", line, true, true, current_ns, config.theme);
 				char *new_ns = get_current_ns(ctx);
 				free(current_ns);
 				free(prompt);

--- a/planck-c/main.c
+++ b/planck-c/main.c
@@ -108,6 +108,7 @@ int main(int argc, char **argv) {
 	config.verbose = false;
 	config.quiet = false;
 	config.repl = false;
+	config.javascript = false;
 	config.static_fns = false;
 	config.elide_asserts = false;
 	config.cache_path = NULL;
@@ -200,6 +201,7 @@ int main(int argc, char **argv) {
 			break;
 		case 'm':
 			config.main_ns_name = argv[optind - 1];
+			break;
 		case 't':
 			config.theme = argv[optind - 1];
 			break;
@@ -250,7 +252,8 @@ int main(int argc, char **argv) {
 	}
 
 	if (config.main_ns_name != NULL && config.repl) {
-		printf("Only one main-opt can be specified.");
+		printf("Only one main-opt can be specified.\n");
+		exit(1);
 	}
 
 	config.is_tty = isatty(STDIN_FILENO) == 1;

--- a/planck-c/main.c
+++ b/planck-c/main.c
@@ -264,7 +264,7 @@ int main(int argc, char **argv) {
 	for (int i = 0; i < config.num_scripts; i++) {
 		// TODO: exit if not successfull
 		struct script script = config.scripts[i];
-		evaluate_source(ctx, script.type, script.source, script.expression, false, NULL, config.theme);
+		evaluate_source(ctx, script.type, script.source, script.expression, false, NULL, config.theme, true);
 	}
 
 	// Process main arguments
@@ -286,7 +286,7 @@ int main(int argc, char **argv) {
 			script.expression = false;
 		}
 
-		evaluate_source(ctx, script.type, script.source, script.expression, false, NULL, config.theme);
+		evaluate_source(ctx, script.type, script.source, script.expression, false, NULL, config.theme, true);
 	} else if (config.repl) {
 		if (!config.quiet) {
 			banner();
@@ -319,7 +319,7 @@ int main(int argc, char **argv) {
 				JSValueRef res = evaluate_script(ctx, line, "<stdin>");
 				print_value("", ctx, res);
 			} else {
-				evaluate_source(ctx, "text", line, true, true, current_ns, config.theme);
+				evaluate_source(ctx, "text", line, true, true, current_ns, config.theme, true);
 				char *new_ns = get_current_ns(ctx);
 				free(current_ns);
 				free(prompt);


### PR DESCRIPTION
This mirrors the behaviour from the Objective-C version.

The REPL feels *a lot* faster now, because you can start typing almost instantly.

I'm not sure why we have to block `SIGUSR2`, though, as mentioned in the comment.  It might be something linux-specific, but I don't know.  Without it the process hangs and doesn't react to input or `Ctrl-C`/`Ctrl-D`.  (I have to kill it every time...)