### PR TITLE
Port the REPL from Objective-C

### DIFF
--- a/planck-c/cljs.c
+++ b/planck-c/cljs.c
@@ -442,7 +442,7 @@ char *cljs_is_readable(JSContextRef ctx, char *expression) {
 	return value_to_c_string(ctx, result);
 }
 
-bool cljs_indent_space_count(JSContextRef ctx, char *text) {
+int cljs_indent_space_count(JSContextRef ctx, char *text) {
 	block_until_engine_ready();
 
 	int num_arguments = 1;

--- a/planck-c/cljs.h
+++ b/planck-c/cljs.h
@@ -11,4 +11,12 @@ void run_main_in_ns(JSContextRef ctx, char *ns, int argc, char **argv);
 char *get_current_ns();
 char **get_completions(JSContextRef ctx, const char *buffer, int *num_completions);
 
+extern bool cljs_engine_ready;
 void cljs_engine_init(JSContextRef ctx);
+
+void cljs_set_print_sender(JSContextRef ctx, void (*sender)(const char* msg));
+bool cljs_print_newline(JSContextRef ctx);
+
+char *cljs_is_readable(JSContextRef ctx, char *expression);
+bool cljs_indent_space_count(JSContextRef ctx, char *text);
+void cljs_highlight_coords_for_pos(JSContextRef ctx, int pos, char *buf, int num_previous_lines, char **previous_lines, int *num_lines_up, int *highlight_pos);

--- a/planck-c/cljs.h
+++ b/planck-c/cljs.h
@@ -18,5 +18,5 @@ void cljs_set_print_sender(JSContextRef ctx, void (*sender)(const char* msg));
 bool cljs_print_newline(JSContextRef ctx);
 
 char *cljs_is_readable(JSContextRef ctx, char *expression);
-bool cljs_indent_space_count(JSContextRef ctx, char *text);
+int cljs_indent_space_count(JSContextRef ctx, char *text);
 void cljs_highlight_coords_for_pos(JSContextRef ctx, int pos, char *buf, int num_previous_lines, char **previous_lines, int *num_lines_up, int *highlight_pos);

--- a/planck-c/functions.c
+++ b/planck-c/functions.c
@@ -254,14 +254,16 @@ JSValueRef function_eval(JSContextRef ctx, JSObjectRef function, JSObjectRef thi
 
 JSValueRef function_get_term_size(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
 		size_t argc, const JSValueRef args[], JSValueRef* exception) {
-	// if (return_term_size)
-	struct winsize w;
-	ioctl(STDOUT_FILENO, TIOCGWINSZ, &w);
-	JSValueRef  arguments[2];
-	arguments[0] = JSValueMakeNumber(ctx, w.ws_row);
-	arguments[1] = JSValueMakeNumber(ctx, w.ws_col);
-	return JSObjectMakeArray(ctx, 2, arguments, NULL);
-	// return JSValueMakeNull(ctx);
+	if (return_termsize) {
+		struct winsize w;
+		ioctl(STDOUT_FILENO, TIOCGWINSZ, &w);
+		JSValueRef  arguments[2];
+		arguments[0] = JSValueMakeNumber(ctx, w.ws_row);
+		arguments[1] = JSValueMakeNumber(ctx, w.ws_col);
+		return JSObjectMakeArray(ctx, 2, arguments, NULL);
+	} else {
+		return JSValueMakeNull(ctx);
+	}
 }
 
 JSValueRef function_print_fn(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,

--- a/planck-c/globals.h
+++ b/planck-c/globals.h
@@ -24,6 +24,7 @@ struct config {
 	bool static_fns;
 	bool elide_asserts;
 	char *theme;
+	bool dumb_terminal;
 
 	char *main_ns_name;
 	int num_rest_args;

--- a/planck-c/globals.h
+++ b/planck-c/globals.h
@@ -44,3 +44,4 @@ extern struct config config;
 // Mutable variables
 
 extern int exit_value;
+extern bool return_termsize;

--- a/planck-c/jsc_utils.c
+++ b/planck-c/jsc_utils.c
@@ -51,6 +51,10 @@ JSValueRef evaluate_script(JSContextRef ctx, char *script, char *source) {
 }
 
 char *value_to_c_string(JSContextRef ctx, JSValueRef val) {
+	if (JSValueIsNull(ctx, val)) {
+		return NULL;
+	}
+
 	if (!JSValueIsString(ctx, val)) {
 #ifdef DEBUG
 		fprintf(stderr, "WARN: not a string\n");

--- a/planck-c/main.c
+++ b/planck-c/main.c
@@ -101,7 +101,8 @@ void banner() {
 }
 
 struct config config;
-int exit_value;
+int exit_value = 0;
+bool return_termsize = false;
 JSContextRef global_ctx = NULL;
 
 int main(int argc, char **argv) {

--- a/planck-c/main.c
+++ b/planck-c/main.c
@@ -41,7 +41,7 @@ void usage(char *program_name) {
 	printf("    -k path, --cache=path    If dir exists at path, use it for cache\n");
 	printf("    -q, --quiet              Quiet mode\n");
 	printf("    -v, --verbose            Emit verbose diagnostic output\n");
-	// printf("    -d, --dumb-terminal      Disable line editing / VT100 terminal control\n");
+	printf("    -d, --dumb-terminal      Disable line editing / VT100 terminal control\n");
 	printf("    -t theme, --theme=theme  Set the color theme\n");
 	// printf("    -n x, --socket-repl=x    Enable socket REPL where x is port or IP:port\n");
 	printf("    -s, --static-fns         Generate static dispatch function calls\n");
@@ -113,6 +113,7 @@ int main(int argc, char **argv) {
 	config.elide_asserts = false;
 	config.cache_path = NULL;
 	config.theme = "light";
+	config.dumb_terminal = false;
 
 	config.out_path = NULL;
 	config.num_src_paths = 0;
@@ -133,6 +134,7 @@ int main(int argc, char **argv) {
 		{"cache", required_argument, NULL, 'k'},
 		{"eval", required_argument, NULL, 'e'},
 		{"theme", required_argument, NULL, 't'},
+		{"dumb-terminal", no_argument, NULL, 'd'},
 		{"classpath", required_argument, NULL, 'c'},
 		{"auto-cache", no_argument, NULL, 'K'},
 		{"init", required_argument, NULL, 'i'},
@@ -145,7 +147,7 @@ int main(int argc, char **argv) {
 		{0, 0, 0, 0}
 	};
 	int opt, option_index;
-	while ((opt = getopt_long(argc, argv, "h?lvrsak:je:t:c:o:Ki:qm:", long_options, &option_index)) != -1) {
+	while ((opt = getopt_long(argc, argv, "h?lvrsak:je:t:dc:o:Ki:qm:", long_options, &option_index)) != -1) {
 		switch (opt) {
 		case 'h':
 			usage(argv[0]);
@@ -205,6 +207,9 @@ int main(int argc, char **argv) {
 		case 't':
 			config.theme = argv[optind - 1];
 			break;
+		case 'd':
+			config.dumb_terminal = true;
+			break;
 		case 'c':
 			{
 				char *classpath = argv[optind - 1];
@@ -234,6 +239,10 @@ int main(int argc, char **argv) {
 		default:
 			printf("unhandled argument: %c\n", opt);
 		}
+	}
+
+	if (config.dumb_terminal) {
+		config.theme = "dumb";
 	}
 
 	config.num_rest_args = 0;

--- a/planck-c/repl.c
+++ b/planck-c/repl.c
@@ -1,0 +1,365 @@
+#include <ctype.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <pthread.h>
+#include <unistd.h>
+
+#include "linenoise.h"
+
+#include "cljs.h"
+#include "globals.h"
+#include "str.h"
+
+#define EXIT_SUCCESS_INTERNAL 0
+
+pthread_mutex_t eval_lock = PTHREAD_MUTEX_INITIALIZER;
+
+JSContextRef global_ctx;
+
+char *current_ns = "cljs.user";
+char *current_prompt = NULL;
+
+char *history_path = NULL;
+
+char *input = NULL;
+int indent_space_count = 0;
+
+int num_previous_lines = 0;
+char **previous_lines = NULL;
+
+int socket_repl_session_id = 0;
+
+char *form_prompt(char *current_ns, bool is_secondary) {
+	char *prompt = NULL;
+	if (!is_secondary) {
+		if (strlen(current_ns) == 1 && !config.dumb_terminal) {
+			prompt = malloc(6 * sizeof(char));
+			sprintf(prompt, " %s=> ", current_ns);
+		} else {
+			prompt = str_concat(current_ns, "=> ");
+		}
+	} else {
+		if (!config.dumb_terminal) {
+			int len = strlen(current_ns) - 2;
+			prompt = malloc((len + 6) * sizeof(char));
+			memset(prompt, ' ', len);
+			sprintf(prompt + len, "#_=> ");
+		}
+	}
+
+	return prompt;
+}
+
+char *get_input() {
+	char *line = NULL;
+	size_t len = 0;
+	int n = getline(&line, &len, stdin);
+	if (n > 0) {
+		if (line[n-1] == '\n') {
+			line[n-1] = '\0';
+		}
+	}
+	return line;
+}
+
+void display_prompt(char *prompt) {
+	if (prompt != NULL) {
+		fprintf(stdout, "%s", prompt);
+		fflush(stdout);
+	}
+}
+
+bool is_whitespace(char *s) {
+	int len = strlen(s);
+	for (int i = 0; i < len; i++) {
+		if (!isspace(s[i])) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool process_line(JSContextRef ctx, char *input_line) {
+	// Accumulate input lines
+
+	if (input == NULL) {
+		input = input_line;
+	} else {
+		input = realloc(input, (strlen(input) + strlen(input_line) + 2) * sizeof(char));
+		sprintf(input + strlen(input), "\n%s", input_line);
+	}
+
+	num_previous_lines += 1;
+	previous_lines = realloc(previous_lines, num_previous_lines * sizeof(char*));
+	previous_lines[num_previous_lines - 1] = strdup(input_line);
+
+	// Check for explicit exit
+
+	if (strcmp(input, ":cljs/quit") == 0 ||
+			strcmp(input, "quit") == 0 ||
+			strcmp(input, "exit") == 0) {
+		if (socket_repl_session_id == 0) {
+			exit_value = EXIT_SUCCESS_INTERNAL;
+		}
+		return true;
+	}
+
+	// Add input line to history
+
+	if (history_path != NULL && !is_whitespace(input)) {
+		linenoiseHistoryAdd(input_line);
+		linenoiseHistorySave(history_path);
+	}
+
+	// Check if we now have readable forms
+	// and if so, evaluate them
+
+	bool done = false;
+	char *balance_text = NULL;
+
+	while (!done) {
+		if ((balance_text = cljs_is_readable(ctx, input)) != NULL) {
+			input[strlen(input) - strlen(balance_text)] = '\0';
+
+			if (!is_whitespace(input)) { // Guard against empty string being read
+				pthread_mutex_lock(&eval_lock);
+
+				return_termsize = !config.dumb_terminal;
+				// TODO: set exit value
+				evaluate_source(ctx, "text", input, true, true, current_ns, config.theme, true);
+				return_termsize = false;
+
+				pthread_mutex_unlock(&eval_lock);
+
+				if (exit_value != 0) {
+					free(input);
+					return true;
+				}
+			} else {
+				printf("\n");
+			}
+
+			// Now that we've evaluated the input, reset for next round
+			free(input);
+			input = balance_text;
+
+			for (int i = 0; i < num_previous_lines; i++) {
+				free(previous_lines[i]);
+			}
+			free(previous_lines);
+			num_previous_lines = 0;
+			previous_lines = NULL;
+
+			// Fetch the current namespace and use it to set the prompt
+			free(current_ns);
+			free(current_prompt);
+
+			current_ns = get_current_ns(ctx);
+			current_prompt = form_prompt(current_ns, false);
+
+			if (is_whitespace(balance_text)) {
+				done = true;
+				free(input);
+				input = NULL;
+			}
+		} else {
+			// Prepare for reading non-1st of input with secondary prompt
+			if (history_path == NULL) {
+				indent_space_count = cljs_indent_space_count(ctx, input);
+			}
+
+			free(current_prompt);
+			current_prompt = form_prompt(current_ns, true);
+			done = true;
+		}
+	}
+
+	return false;
+}
+
+void run_cmdline_loop(JSContextRef ctx) {
+	while (true) {
+		char *input_line = NULL;
+
+		if (config.dumb_terminal) {
+			display_prompt(current_prompt);
+			input_line = get_input();
+			if (input_line == NULL) { // Ctrl-D pressed
+				printf("\n");
+				break;
+			}
+		} else {
+			// Handle prints while processing linenoise input
+			if (cljs_engine_ready) {
+				cljs_set_print_sender(ctx, &linenoisePrintNow);
+			}
+
+			// If *print-newline* is off, we need to emit a newline now, otherwise
+			// the linenoise prompt and line editing will overwrite any printed
+			// output on the current line.
+			if (cljs_engine_ready && !cljs_print_newline(ctx)) {
+				fprintf(stdout, "\n");
+			}
+
+			char *line = linenoise(current_prompt, "\x1b[36m", indent_space_count);
+
+			// Reset printing handler back
+			if (cljs_engine_ready) {
+				cljs_set_print_sender(ctx, NULL);
+			}
+
+			indent_space_count = 0;
+			if (line == NULL) {
+				if (errno == EAGAIN) { // Ctrl-C
+					errno = 0;
+					input = NULL;
+					// empty_previous_lines
+					current_prompt = form_prompt(current_ns, false);
+					printf("\n");
+					continue;
+				} else { // Ctrl-D
+					exit_value = EXIT_SUCCESS_INTERNAL;
+					break;
+				}
+			}
+
+			input_line = line;
+		}
+
+		bool break_out = process_line(ctx, input_line);
+		if (break_out) {
+			break;
+		}
+	}
+}
+
+void completion(const char *buf, linenoiseCompletions *lc) {
+	int num_completions = 0;
+	char **completions = get_completions(global_ctx, buf, &num_completions);
+	for (int i = 0; i < num_completions; i++) {
+		linenoiseAddCompletion(lc, completions[i]);
+		free(completions[i]);
+	}
+	free(completions);
+}
+
+struct hl_restore {
+	bool should_restore;
+	int num_lines_up;
+	int relative_horiz;
+
+};
+struct hl_restore hl_restore;
+
+void *do_highlight_restore(void *data) {
+	if (data != NULL) {
+		int *timeout = data;
+		struct timespec t;
+		t.tv_sec = 0;
+		t.tv_nsec = *timeout;
+		clock_nanosleep(CLOCK_REALTIME, 0, &t, NULL);
+	}
+
+	if (hl_restore.num_lines_up != 0) {
+		fprintf(stdout,"\x1b[%dB", hl_restore.num_lines_up);
+	}
+
+	if (hl_restore.relative_horiz < 0) {
+		fprintf(stdout,"\x1b[%dC", -hl_restore.relative_horiz);
+	} else if (hl_restore.relative_horiz > 0){
+		fprintf(stdout,"\x1b[%dD", hl_restore.relative_horiz);
+	}
+
+	fflush(stdout);
+
+	hl_restore.should_restore = false;
+	hl_restore.num_lines_up = 0;
+	hl_restore.relative_horiz = 0;
+
+	return NULL;
+}
+
+void highlight(const char *buf, int pos) {
+	char current = buf[pos];
+
+	if (current == ']' || current == '}' || current == ')') {
+		int num_lines_up = -1;
+		int highlight_pos = 0;
+		char *buf_copy = malloc((pos + 1) * sizeof(char));
+		strncpy(buf_copy, buf, pos);
+		buf_copy[pos + 1] = '\0';
+		cljs_highlight_coords_for_pos(global_ctx, pos, (char*)buf, num_previous_lines, previous_lines, &num_lines_up, &highlight_pos);
+		free(buf_copy);
+
+		int current_pos = pos + 1;
+
+		if (num_lines_up != -1) {
+			int relative_horiz = highlight_pos - current_pos;
+
+			if (num_lines_up != 0) {
+				fprintf(stdout,"\x1b[%dA", num_lines_up);
+			}
+
+			if (relative_horiz < 0) {
+				fprintf(stdout,"\x1b[%dD", -relative_horiz);
+			} else if (relative_horiz > 0){
+				fprintf(stdout,"\x1b[%dC", relative_horiz);
+			}
+
+			fflush(stdout);
+
+			// struct hl_restore *hl_restore = malloc(sizeof(struct hl_restore));
+			hl_restore.should_restore = true;
+			hl_restore.num_lines_up = num_lines_up;
+			hl_restore.relative_horiz = relative_horiz;
+
+			int timeout = 250 * 1000 * 1000;
+			pthread_attr_t attr;
+			pthread_attr_init(&attr);
+			pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+			pthread_t thread;
+			pthread_create(&thread, &attr, do_highlight_restore, (void*)&timeout);
+		}
+	}
+}
+
+void highlight_cancel() {
+	if (hl_restore.should_restore) {
+		do_highlight_restore(NULL);
+	}
+}
+
+int run_repl(JSContextRef ctx) {
+	global_ctx = ctx;
+
+	current_ns = strdup("cljs.user");
+	current_prompt = form_prompt(current_ns, false);
+
+	// Per-type initialization
+
+	if (!config.dumb_terminal) {
+		char *home = getenv("HOME");
+		if (home != NULL) {
+			char history_name[] = ".planck_history";
+			int len = strlen(home) + strlen(history_name) + 2;
+			history_path = malloc(len * sizeof(char));
+			snprintf(history_path, len, "%s/%s", home, history_name);
+
+			linenoiseHistoryLoad(history_path);
+
+			// TODO: load keymap
+		}
+
+		linenoiseSetMultiLine(1);
+		linenoiseSetCompletionCallback(completion);
+		linenoiseSetHighlightCallback(highlight);
+		linenoiseSetHighlightCancelCallback(highlight_cancel);
+	}
+
+	run_cmdline_loop(ctx);
+
+	return exit_value;
+}

--- a/planck-c/repl.c
+++ b/planck-c/repl.c
@@ -167,7 +167,7 @@ bool process_line(JSContextRef ctx, char *input_line) {
 			}
 		} else {
 			// Prepare for reading non-1st of input with secondary prompt
-			if (history_path == NULL) {
+			if (history_path != NULL) {
 				indent_space_count = cljs_indent_space_count(ctx, input);
 			}
 

--- a/planck-c/repl.c
+++ b/planck-c/repl.c
@@ -31,6 +31,15 @@ char **previous_lines = NULL;
 
 int socket_repl_session_id = 0;
 
+void empty_previous_lines() {
+	for (int i = 0; i < num_previous_lines; i++) {
+		free(previous_lines[i]);
+	}
+	free(previous_lines);
+	num_previous_lines = 0;
+	previous_lines = NULL;
+}
+
 char *form_prompt(char *current_ns, bool is_secondary) {
 	char *prompt = NULL;
 	if (!is_secondary) {
@@ -146,12 +155,7 @@ bool process_line(JSContextRef ctx, char *input_line) {
 			free(input);
 			input = balance_text;
 
-			for (int i = 0; i < num_previous_lines; i++) {
-				free(previous_lines[i]);
-			}
-			free(previous_lines);
-			num_previous_lines = 0;
-			previous_lines = NULL;
+			empty_previous_lines();
 
 			// Fetch the current namespace and use it to set the prompt
 			free(current_ns);
@@ -216,7 +220,7 @@ void run_cmdline_loop(JSContextRef ctx) {
 				if (errno == EAGAIN) { // Ctrl-C
 					errno = 0;
 					input = NULL;
-					// empty_previous_lines
+					empty_previous_lines();
 					current_prompt = form_prompt(current_ns, false);
 					printf("\n");
 					continue;

--- a/planck-c/repl.h
+++ b/planck-c/repl.h
@@ -1,0 +1,1 @@
+int run_repl(JSContextRef ctx);


### PR DESCRIPTION
This should bring everything from the Objective-C REPL except socket REPLs and custom keybindings.

In particular, the following should all work:

- multiline editing (including indenting following lines)
- paren matching
- exiting with `:cljs/quit`, `quit` or `exit`
- completion should still work

One thing that should be fixed in the future is that we spawn a thread *every time* we want to jump to a parenthesis.  This could probably be done smarter.