### PR TITLE
Use nanosleep on all systems

### DIFF
--- a/planck-c/repl.c
+++ b/planck-c/repl.c
@@ -264,11 +264,7 @@ void *do_highlight_restore(void *data) {
 		struct timespec t;
 		t.tv_sec = 0;
 		t.tv_nsec = *timeout;
-#ifdef CLOCK_REALTIME
-		clock_nanosleep(CLOCK_REALTIME, 0, &t, NULL);
-#else
 		nanosleep(&t, NULL);
-#endif
 	}
 
 	if (hl_restore.num_lines_up != 0) {


### PR DESCRIPTION
Makes the code a tiny bit simpler.  The earlier code only used `clock_nanosleep` because I wasn't sure whether `nanosleep` was part of the POSIX APIs.