### PR TITLE
Add js/PLANCK_VERSION again

### DIFF
--- a/planck-c/cljs.c
+++ b/planck-c/cljs.c
@@ -305,6 +305,8 @@ void *cljs_do_engine_init(void *data) {
 			"console.log = PLANCK_CONSOLE_LOG;"\
 			"console.error = PLANCK_CONSOLE_ERROR;", "<init>");
 
+	evaluate_script(ctx, "var PLANCK_VERSION = \"" PLANCK_VERSION "\";", "<init>");
+
 	// require app namespaces
 	evaluate_script(ctx, "goog.require('planck.repl');", "<init>");
 


### PR DESCRIPTION
It got lost in the background thread work somehow.  (And broke the `planck.http` namespace.)