### PR TITLE
Implement planck.shell/sh.

### DIFF
--- a/planck-c/Makefile
+++ b/planck-c/Makefile
@@ -4,7 +4,7 @@ VERSION = $(shell git describe --tags)
 
 CC = clang
 
-CFLAGS = -Wall -DDEBUG -fsanitize=address
+CFLAGS = -Wall -DDEBUG #-fsanitize=address
 UNAME_S = $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
 	JSCDEP = $(shell pkg-config --exists javascriptcoregtk-4.0 && echo "javascriptcoregtk-4.0" || echo "javascriptcoregtk-3.0")

--- a/planck-c/Makefile
+++ b/planck-c/Makefile
@@ -4,7 +4,7 @@ VERSION = $(shell git describe --tags)
 
 CC = clang
 
-CFLAGS = -Wall -DDEBUG
+CFLAGS = -Wall -DDEBUG -fsanitize=address
 UNAME_S = $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
 	JSCDEP = $(shell pkg-config --exists javascriptcoregtk-4.0 && echo "javascriptcoregtk-4.0" || echo "javascriptcoregtk-3.0")

--- a/planck-c/README.md
+++ b/planck-c/README.md
@@ -1,9 +1,8 @@
 # planck-c
 
-This is an in-progress port of Planck to C, supporting multiple
-platforms.
+Planck 2.0: This is an in-progress port of Planck 1.x to C, supporting Linux and OS X.
 
-**Warning:** *This is very much a work in progress.  Lots of stuff is still missing, things might not work, ...  Feel free to port things from the Objective-C version of planck.*
+**Warning:** *This is very much a work in progress.  Lots of stuff is still missing, things might not work.  Feel free to port things from the Objective-C version of Planck 1.x. See [TODOs](https://github.com/mfikes/planck/wiki/Planck-C-TODOs).*
 
 ## Development
 
@@ -25,6 +24,6 @@ You can run the "integration tests" by executing the following from the root of 
 - based on JavaScriptCore (from webkitgtk)
 - uses `planck-cljs`
 - access to native capabilities via a reimplementation of
-    planck's Objective-C part
+    Planck's Objective-C part
 
 A lot of stuff is still missing (in fact most of it).

--- a/planck-c/cljs.c
+++ b/planck-c/cljs.c
@@ -11,6 +11,7 @@
 #include "functions.h"
 #include "globals.h"
 #include "http.h"
+#include "shell.h"
 #include "io.h"
 #include "jsc_utils.h"
 #include "str.h"
@@ -325,6 +326,8 @@ void *cljs_do_engine_init(void *data) {
 	register_global_function(ctx, "PLANCK_PRINT_ERR_FN", function_print_err_fn);
 
 	register_global_function(ctx, "PLANCK_SET_EXIT_VALUE", function_set_exit_value);
+
+	register_global_function(ctx, "PLANCK_SHELL_SH", function_shellexec);
 
 	register_global_function(ctx, "PLANCK_RAW_READ_STDIN", function_raw_read_stdin);
 	register_global_function(ctx, "PLANCK_RAW_WRITE_STDOUT", function_raw_write_stdout);

--- a/planck-c/cljs.c
+++ b/planck-c/cljs.c
@@ -454,7 +454,7 @@ int cljs_indent_space_count(JSContextRef ctx, char *text) {
     return JSValueToNumber(ctx, result, NULL);
 }
 
-void cljs_highlight_coords_for_pos(JSContextRef ctx, int pos, char *buf, int num_previous_lines, char **previous_lines, int *num_lines_up, int *highlight_pos) {
+void cljs_highlight_coords_for_pos(JSContextRef ctx, int pos, const char *buf, int num_previous_lines, char **previous_lines, int *num_lines_up, int *highlight_pos) {
 	block_until_engine_ready();
 
 	int num_arguments = 3;

--- a/planck-c/cljs.h
+++ b/planck-c/cljs.h
@@ -19,4 +19,4 @@ bool cljs_print_newline(JSContextRef ctx);
 
 char *cljs_is_readable(JSContextRef ctx, char *expression);
 int cljs_indent_space_count(JSContextRef ctx, char *text);
-void cljs_highlight_coords_for_pos(JSContextRef ctx, int pos, char *buf, int num_previous_lines, char **previous_lines, int *num_lines_up, int *highlight_pos);
+void cljs_highlight_coords_for_pos(JSContextRef ctx, int pos, const char *buf, int num_previous_lines, char **previous_lines, int *num_lines_up, int *highlight_pos);

--- a/planck-c/jsc_utils.c
+++ b/planck-c/jsc_utils.c
@@ -72,7 +72,7 @@ char *value_to_c_string(JSContextRef ctx, JSValueRef val) {
 	return str;
 }
 
-JSValueRef c_string_to_value(JSContextRef ctx, char *s) {
+JSValueRef c_string_to_value(JSContextRef ctx, const char *s) {
 	JSStringRef str = JSStringCreateWithUTF8CString(s);
 	return JSValueMakeString(ctx, str);
 }

--- a/planck-c/jsc_utils.c
+++ b/planck-c/jsc_utils.c
@@ -63,7 +63,7 @@ char *value_to_c_string(JSContextRef ctx, JSValueRef val) {
 	}
 
 	JSStringRef str_ref = JSValueToStringCopy(ctx, val, NULL);
-	size_t len = JSStringGetLength(str_ref) + 1;
+	size_t len = JSStringGetMaximumUTF8CStringSize(str_ref);
 	char *str = malloc(len * sizeof(char));
 	memset(str, 0, len);
 	JSStringGetUTF8CString(str_ref, str, len);

--- a/planck-c/jsc_utils.h
+++ b/planck-c/jsc_utils.h
@@ -14,4 +14,4 @@ JSValueRef evaluate_script(JSContextRef ctx, char *script, char *source);
 
 char *value_to_c_string(JSContextRef ctx, JSValueRef val);
 
-JSValueRef c_string_to_value(JSContextRef ctx, char *s);
+JSValueRef c_string_to_value(JSContextRef ctx, const char *s);

--- a/planck-c/legal.c
+++ b/planck-c/legal.c
@@ -14,14 +14,6 @@ void legal() {
 	printf("which is hereby acknowledged.\n");
 	printf("\n");
 	
-	// printf("Ambly\n");
-	// printf("-----\n");
-	// printf("\n");
-	// printf("Copyright © 2015 David Nolen\n");
-	// printf("Licensed under the Eclipse Public License.\n");
-	// printf("\n");
-	// printf("\n");
-	
 	printf("Fipp\n");
 	printf("-----\n");
 	printf("\n");
@@ -61,14 +53,6 @@ void legal() {
 	printf("\n");
 	printf("\n");
 	
-	// printf("MPEdn\n");
-	// printf("-----\n");
-	// printf("\n");
-	// printf("Developed by Matthew Phillips\n");
-	// printf("Licensed under the Eclipse Public License v1.0.\n");
-	// printf("\n");
-	// printf("\n");
-	
 	printf("Parinfer\n");
 	printf("-----\n");
 	printf("\n");
@@ -84,33 +68,4 @@ void legal() {
 	printf("\n");
 	printf("Apache Software License 2.0.\n");
 	printf("http://www.apache.org/licenses/LICENSE-2.0\n");
-	// printf("\n");
-	// printf("\n");
-	
-	// printf("ZipZap\n");
-	// printf("------\n");
-	// printf("\n");
-	// printf("Copyright (c) 2012, Pixelglow Software.\n");
-	// printf("All rights reserved.\n");
-	// printf("\n");
-	// printf("Redistribution and use in source and binary forms, with or without\n");
-	// printf("modification, are permitted provided that the following conditions are met:\n");
-	// printf("\n");
-	// printf("* Redistributions of source code must retain the above copyright notice,\n");
-	// printf("this list of conditions and the following disclaimer.\n");
-	// printf("\n");
-	// printf("* Redistributions in binary form must reproduce the above copyright notice,\n");
-	// printf("this list of conditions and the following disclaimer in the documentation\n");
-	// printf("and/or other materials provided with the distribution.\n");
-	// printf("\n");
-	// printf("THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\" AND\n");
-	// printf("ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED\n");
-	// printf("WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\n");
-	// printf("DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR\n");
-	// printf("ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES\n");
-	// printf("(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;\n");
-	// printf("LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON\n");
-	// printf("ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n");
-	// printf("(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS\n");
-	// printf("SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n");
 }

--- a/planck-c/main.c
+++ b/planck-c/main.c
@@ -1,30 +1,18 @@
-#include <assert.h>
 #include <errno.h>
 #include <getopt.h>
 #include <libgen.h>
-#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/stat.h>
-#include <time.h>
 #include <unistd.h>
-
-#include <JavaScriptCore/JavaScript.h>
-
-#include "linenoise.h"
 
 #include "bundle.h"
 #include "cljs.h"
 #include "globals.h"
 #include "io.h"
-#include "jsc_utils.h"
 #include "legal.h"
 #include "repl.h"
 #include "str.h"
-#include "zip.h"
-
-void completion(const char *buf, linenoiseCompletions *lc);
 
 void usage(char *program_name) {
 	printf("Planck %s\n", PLANCK_VERSION);
@@ -181,7 +169,7 @@ int main(int argc, char **argv) {
 			config.elide_asserts = true;
 			break;
 		case 'k':
-			config.cache_path = argv[optind - 1];
+			config.cache_path = strdup(optarg);
 			break;
 		case 'K':
 			config.cache_path = ".planck_cache";
@@ -202,27 +190,27 @@ int main(int argc, char **argv) {
 			config.scripts = realloc(config.scripts, config.num_scripts * sizeof(struct script));
 			config.scripts[config.num_scripts - 1].type = "text";
 			config.scripts[config.num_scripts - 1].expression = true;
-			config.scripts[config.num_scripts - 1].source = argv[optind - 1];
+			config.scripts[config.num_scripts - 1].source = strdup(optarg);
 			break;
 		case 'i':
 			config.num_scripts += 1;
 			config.scripts = realloc(config.scripts, config.num_scripts * sizeof(struct script));
 			config.scripts[config.num_scripts - 1].type = "path";
 			config.scripts[config.num_scripts - 1].expression = false;
-			config.scripts[config.num_scripts - 1].source = argv[optind - 1];
+			config.scripts[config.num_scripts - 1].source = strdup(optarg);
 			break;
 		case 'm':
-			config.main_ns_name = argv[optind - 1];
+			config.main_ns_name = strdup(optarg);
 			break;
 		case 't':
-			config.theme = argv[optind - 1];
+			config.theme = strdup(optarg);
 			break;
 		case 'd':
 			config.dumb_terminal = true;
 			break;
 		case 'c':
 			{
-				char *classpath = argv[optind - 1];
+				char *classpath = strdup(optarg);
 				char *source = strtok(classpath, ":");
 				while (source != NULL) {
 					char *type = "src";
@@ -241,7 +229,7 @@ int main(int argc, char **argv) {
 				break;
 			}
 		case 'o':
-			config.out_path = ensure_trailing_slash(argv[optind - 1]);
+			config.out_path = ensure_trailing_slash(strdup(optarg));
 			break;
 		case '?':
 			usage(argv[0]);

--- a/planck-c/repl.c
+++ b/planck-c/repl.c
@@ -306,11 +306,7 @@ void highlight(const char *buf, int pos) {
 	if (current == ']' || current == '}' || current == ')') {
 		int num_lines_up = -1;
 		int highlight_pos = 0;
-		char *buf_copy = malloc((pos + 2) * sizeof(char));
-		strncpy(buf_copy, buf, pos);
-		buf_copy[pos + 1] = '\0';
-		cljs_highlight_coords_for_pos(global_ctx, pos, (char*)buf, num_previous_lines, previous_lines, &num_lines_up, &highlight_pos);
-		free(buf_copy);
+		cljs_highlight_coords_for_pos(global_ctx, pos, buf, num_previous_lines, previous_lines, &num_lines_up, &highlight_pos);
 
 		int current_pos = pos + 1;
 

--- a/planck-c/repl.c
+++ b/planck-c/repl.c
@@ -306,7 +306,7 @@ void highlight(const char *buf, int pos) {
 	if (current == ']' || current == '}' || current == ')') {
 		int num_lines_up = -1;
 		int highlight_pos = 0;
-		char *buf_copy = malloc((pos + 1) * sizeof(char));
+		char *buf_copy = malloc((pos + 2) * sizeof(char));
 		strncpy(buf_copy, buf, pos);
 		buf_copy[pos + 1] = '\0';
 		cljs_highlight_coords_for_pos(global_ctx, pos, (char*)buf, num_previous_lines, previous_lines, &num_lines_up, &highlight_pos);

--- a/planck-c/shell.c
+++ b/planck-c/shell.c
@@ -117,8 +117,10 @@ struct SystemResult system_call(char* cmd, char** env, char* dir) {
     close(err[1]);
     close(in[1]);
     if (waitpid(pid, &res.status, 0) != pid) res.status = -1;
-    res.stderr = read_child_pipe(err[0]);
-    res.stdout = read_child_pipe(in[0]);
+    else {
+      res.stderr = read_child_pipe(err[0]);
+      res.stdout = read_child_pipe(in[0]);
+    }
   }
   return res;
 }

--- a/planck-c/shell.c
+++ b/planck-c/shell.c
@@ -142,13 +142,13 @@ JSValueRef function_shellexec(JSContextRef ctx, JSObjectRef function, JSObjectRe
       if (!JSValueIsNull(ctx, args[5])) {
         dir = value_to_c_string(ctx, args[5]);
 #ifdef DEBUG
-        printf("dir: %s", dir);
+        printf("dir: %s\n", dir);
 #endif
       }
       struct SystemResult result = system_call(joined, environment, dir);
 #ifdef DEBUG
-      printf("stdout: %s", result.stdout);
-      printf("stderr: %s", result.stderr);
+      printf("stdout: %s\n", result.stdout);
+      printf("stderr: %s\n", result.stderr);
 #endif
 
       JSValueRef arguments[3];

--- a/planck-c/shell.c
+++ b/planck-c/shell.c
@@ -2,6 +2,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 #include <JavaScriptCore/JavaScript.h>
 #include "jsc_utils.h"
 

--- a/planck-c/shell.c
+++ b/planck-c/shell.c
@@ -1,0 +1,167 @@
+#include <assert.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <JavaScriptCore/JavaScript.h>
+#include "jsc_utils.h"
+
+static int JSArrayGetCount(JSContextRef ctx, JSObjectRef arr)
+{
+  JSStringRef pname = JSStringCreateWithUTF8CString("length");
+  JSValueRef val = JSObjectGetProperty(ctx, arr, pname, NULL);
+  JSStringRelease(pname);
+  return JSValueToNumber(ctx, val, NULL);
+}
+
+#define JSArrayGetValueAtIndex(ctx, array, i) JSObjectGetPropertyAtIndex(ctx, array, i, NULL)
+
+static char* cmd(JSContextRef ctx, const JSObjectRef array) {
+  int argc = JSArrayGetCount(ctx, array);
+  char** args = malloc(sizeof(char*) * argc);
+  int total_size = 0;
+  for (int i = 0; i < argc; i++) {
+    JSValueRef val = JSArrayGetValueAtIndex(ctx, array, i);
+    if (JSValueGetType(ctx, val) != kJSTypeString) return NULL;
+    args[i] = value_to_c_string(ctx, val);
+    total_size += strlen(args[i]) + 1;
+  }
+  char* result = malloc(total_size + 1 + argc);
+  result[0] = 0;
+  for (int i = 0; i < argc; i++) {
+    strcat(result, args[i]);
+    strcat(result, " ");
+    free(args[i]);
+  }
+  free(args);
+  return result;
+}
+
+static char** env(JSContextRef ctx, const JSObjectRef map) {
+  int argc = JSArrayGetCount(ctx, map);
+  char** result = NULL;
+  if (argc > 0) {
+    result = malloc(sizeof(char*) * (argc + 1));
+    for (int i = 0; i < argc; i++) {
+      JSObjectRef keyVal = (JSObjectRef) JSArrayGetValueAtIndex(ctx, map, i);
+      char* key = value_to_c_string(ctx, JSArrayGetValueAtIndex(ctx, keyVal, 0));
+      char* value = value_to_c_string(ctx, JSArrayGetValueAtIndex(ctx, keyVal, 1));
+      int len = strlen(key) + strlen(value) + 2;
+      char* combined = malloc(len);
+      combined[0] = 0;
+      snprintf(combined, len, "%s=%s", key, value);
+      free(key);
+      free(value);
+      result[i] = combined;
+#ifdef DEBUG
+      printf("env[%d]: %s\n", i, combined);
+#endif
+    }
+    result[argc] = 0;
+  }
+  return result;
+}
+
+static void preopen(int old, int new) {
+  dup2(old, new);
+  close(old);
+}
+
+static char* read_child_pipe(int pipe) {
+  const int BLOCK_SIZE = 1024;
+  int block_count = 1;
+  char* res = malloc(BLOCK_SIZE * block_count);
+  int count = 0;
+  int total = 0;
+  do {
+    count = read(pipe, res + total, BLOCK_SIZE);
+    if (count > 0) {
+      total += count;
+      block_count += 1;
+      res = realloc(res, BLOCK_SIZE * block_count);
+    }
+  } while (count == BLOCK_SIZE);
+  res[total] = 0;
+  return res;
+}
+
+struct SystemResult {
+  int status;
+  char* stdout;
+  char* stderr;
+};
+
+struct SystemResult system_call(char* cmd, char** env, char* dir) {
+  struct SystemResult res = {0};
+
+  int in[2]; pipe(in);
+  int out[2]; pipe(out);
+  int err[2]; pipe(err);
+
+  pid_t pid;
+  pid = fork();
+  if (pid == 0) {
+    if (dir) chdir(dir);
+    preopen(out[0], STDIN_FILENO);
+    preopen(err[1], STDERR_FILENO);
+    preopen(in[1], STDOUT_FILENO);
+    close(out[1]);
+    close(err[0]);
+    close(in[0]);
+    char* argv[] = { "/bin/sh", "-c", cmd, 0 };
+    execve(argv[0], &argv[0], env);
+    _exit(EXIT_FAILURE);
+  } else if (pid < 0) {
+    res.status = -1;
+  } else {
+    close(out[0]);
+    close(err[1]);
+    close(in[1]);
+    if (waitpid(pid, &res.status, 0) != pid) res.status = -1;
+    res.stderr = read_child_pipe(err[0]);
+    res.stdout = read_child_pipe(in[0]);
+  }
+  return res;
+}
+
+JSValueRef function_shellexec(JSContextRef ctx, JSObjectRef function, JSObjectRef this_object,
+		size_t argc, const JSValueRef args[], JSValueRef* exception) {
+  if (argc == 6) {
+    char* joined = cmd(ctx, (JSObjectRef) args[0]);
+    if (joined) {
+#ifdef DEBUG
+      printf("cmd: %s\n", joined);
+#endif
+      char** environment = NULL;
+      if (!JSValueIsNull(ctx, args[4])) {
+        environment = env(ctx, (JSObjectRef) args[4]);
+      }
+      char* dir = NULL;
+      if (!JSValueIsNull(ctx, args[5])) {
+        dir = value_to_c_string(ctx, args[5]);
+#ifdef DEBUG
+        printf("dir: %s", dir);
+#endif
+      }
+      struct SystemResult result = system_call(joined, environment, dir);
+#ifdef DEBUG
+      printf("stdout: %s", result.stdout);
+      printf("stderr: %s", result.stderr);
+#endif
+
+      JSValueRef arguments[3];
+      arguments[0] = JSValueMakeNumber(ctx, result.status);
+      arguments[1] = c_string_to_value(ctx, result.stdout);
+      arguments[2] = c_string_to_value(ctx, result.stderr);
+
+      free(result.stdout);
+      free(result.stderr);
+      free(dir);
+      free(environment);
+      free(joined);
+
+      return JSObjectMakeArray(ctx, 3, arguments, NULL);
+    }
+  }
+  return JSValueMakeNull(ctx);
+}
+

--- a/planck-c/shell.h
+++ b/planck-c/shell.h
@@ -1,0 +1,4 @@
+#include <JavaScriptCore/JavaScript.h>
+
+JSValueRef function_shellexec(JSContextRef ctx, JSObjectRef function, JSObjectRef this_object,
+		size_t argc, const JSValueRef args[], JSValueRef* exception);

--- a/planck-cljs/project.clj
+++ b/planck-cljs/project.clj
@@ -1,11 +1,11 @@
 (defproject planck "0.1.0"
   :profiles {:dev
-             {:dependencies [[org.clojure/clojurescript "1.9.76"]
+             {:dependencies [[org.clojure/clojurescript "1.9.88"]
                              [tubular "1.0.0"]]
               :source-paths ["dev"]}
              :build {}}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/clojurescript "1.9.76"]       ; comment if building own, and revise planck-cljs/script/build
+                 [org.clojure/clojurescript "1.9.88"]       ; comment if building own, and revise planck-cljs/script/build
                  [org.clojure/tools.reader "1.0.0-beta1"]
                  [tailrecursion/cljson "1.0.7"]
                  [com.cognitect/transit-clj "0.8.285"]

--- a/planck-cljs/src/planck/shell.cljs
+++ b/planck-cljs/src/planck/shell.cljs
@@ -35,7 +35,7 @@
     (let [{:keys [in in-enc out-enc env dir]}
           (merge {:out-enc nil :in-enc nil :dir *sh-dir* :env *sh-env*}
             (into {} (map (comp (juxt :key :val) second) opts)))
-          dir (and dir (:path (as-file dir)))
+          dir (and dir (:path (as-file (second dir))))
           [exit out err] (js->clj (js/PLANCK_SHELL_SH (clj->js cmd) in in-enc out-enc (clj->js (seq env)) dir))]
       (if (and (== -1 exit)
                (= "launch path not accessible" err))

--- a/script/build
+++ b/script/build
@@ -44,15 +44,15 @@ OS_LION_RE='^10\.7\..*'
 
 echo "### Building 1st Stage Binary"
 if [[ $OS_VERSION =~ $OS_LION_RE ]] ; then
-    xcodebuild -project planck.xcodeproj -scheme planck -configuration $CONFIGURATION SYMROOT=$(PWD)/$BUILD_DIR
+    xcodebuild -project planck.xcodeproj -scheme planck -configuration $CONFIGURATION SYMROOT=$(pwd)/$BUILD_DIR
 else
-    xcodebuild -project planck.xcodeproj -scheme planck -configuration $CONFIGURATION SYMROOT=$(PWD)/$BUILD_DIR -derivedDataPath $BUILD_DIR/DerivedData
+    xcodebuild -project planck.xcodeproj -scheme planck -configuration $CONFIGURATION SYMROOT=$(pwd)/$BUILD_DIR -derivedDataPath $BUILD_DIR/DerivedData
 fi
 checkCmdSuccess
 
 echo "### Compiling Macro Namespaces"
 mkdir -p planck-cljs/out/macros-tmp
-$(PWD)/$BUILD_DIR/$CONFIGURATION/planck --quiet -sdk planck-cljs/out/macros-tmp <<REPL_INPUT
+$(pwd)/$BUILD_DIR/$CONFIGURATION/planck --quiet -sdk planck-cljs/out/macros-tmp <<REPL_INPUT
 (require-macros 
   'planck.repl
   'planck.core 
@@ -99,10 +99,10 @@ cd ..
 
 echo "### Building 2nd Stage Binary"
 if [[ $OS_VERSION =~ $OS_LION_RE ]] ; then
-    xcodebuild -project planck.xcodeproj -scheme planck -configuration $CONFIGURATION SYMROOT=$(PWD)/$BUILD_DIR
+    xcodebuild -project planck.xcodeproj -scheme planck -configuration $CONFIGURATION SYMROOT=$(pwd)/$BUILD_DIR
 else
-    xcodebuild -project planck.xcodeproj -scheme planck -configuration $CONFIGURATION SYMROOT=$(PWD)/$BUILD_DIR -derivedDataPath $BUILD_DIR/DerivedData
+    xcodebuild -project planck.xcodeproj -scheme planck -configuration $CONFIGURATION SYMROOT=$(pwd)/$BUILD_DIR -derivedDataPath $BUILD_DIR/DerivedData
 fi
 checkCmdSuccess
 
-echo "Binary located at $(PWD)/$BUILD_DIR/$CONFIGURATION/planck"
+echo "Binary located at $(pwd)/$BUILD_DIR/$CONFIGURATION/planck"


### PR DESCRIPTION
No support for `:in` yet. `:in-enc` and `:out-enc` are rightly ignored in the native context.