### PR TITLE
Close file descriptors after child termination.

### DIFF
--- a/planck-c/shell.c
+++ b/planck-c/shell.c
@@ -194,6 +194,10 @@ static JSValueRef system_call(JSContextRef ctx, char** cmd, char** env, char* di
       }
     }
 
+    close(out[1]);
+    close(err[0]);
+    close(in[0]);
+
     for (int i = 0; cmd[i] != NULL; i++)
       free(cmd[i]);
     free(cmd);


### PR DESCRIPTION
Here is a small fix for a fd leak issue I found in planck-c/shell.c: the parent side of the communication pipes is never closed.

The following loop shows the issue:
```
(require '[planck.shell :refer [sh]])
(loop [x 1]
 (sh "echo" "A")
 (print x)(newline)
 (if (< x 1000) (recur (+ x 1))))
```
After a while all the fds are used up and the pipe() calls fail, so the output from echo is displayed on the screen.

I think we'd also need some more checking on function calls (e.g. pipe(), here), but then, how should the error/exception reported back to clojure?

This kind of checking/reporting would also be nice, for instance, for the cases in which sh fails due to non existing executable, as it happens in clojure:
```
user=> (sh "xxx")
IOException error=2, No such file or directory  java.lang.UNIXProcess.forkAndExec (UNIXProcess.java:-2)
```
