### PR TITLE
:kind -> kind

### DIFF
--- a/planck-cljs/src/planck/repl.cljs
+++ b/planck-cljs/src/planck/repl.cljs
@@ -397,7 +397,7 @@
   [kind cb specs]
   (let [memo (compiler-state-memo)]
     (try
-      (let [is-self-require? (and (= :kind :require) (self-require? specs))
+      (let [is-self-require? (and (= kind :require) (self-require? specs))
             [target-ns restore-ns]
             (if-not is-self-require?
               [@current-ns nil]


### PR DESCRIPTION
Looks like a typo in the variable name. The check `(= :kind :require)` would never pass, it should use the variable name (`kind`) instead