### PR TITLE
Replaced all shebang by more portable ones 

### DIFF
--- a/int-test/script/certify
+++ b/int-test/script/certify
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source int-test/script/setup-env
 cp $ACTUAL_PATH/PLANCK-OUT.txt $EXPECTED_PATH/PLANCK-OUT.txt

--- a/int-test/script/gen-actual
+++ b/int-test/script/gen-actual
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #######################################################
 # Take a look at int-test/script/int-tests

--- a/int-test/script/run-tests
+++ b/int-test/script/run-tests
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source int-test/script/setup-env
 int-test/script/gen-actual > $ACTUAL_PATH/PLANCK-OUT.txt 2> $ACTUAL_PATH/PLANCK-ERR.txt

--- a/int-test/script/run-tests-c
+++ b/int-test/script/run-tests-c
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source int-test/script/setup-env-c
 int-test/script/gen-actual > $ACTUAL_PATH/PLANCK-OUT.txt 2> $ACTUAL_PATH/PLANCK-ERR.txt

--- a/int-test/script/setup-env
+++ b/int-test/script/setup-env
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export EXPECTED_PATH=int-test/expected
 export ACTUAL_PATH=/tmp

--- a/int-test/script/setup-env-c
+++ b/int-test/script/setup-env-c
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export EXPECTED_PATH=int-test/expected
 export ACTUAL_PATH=/tmp

--- a/planck-cljs/script/build
+++ b/planck-cljs/script/build
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Make sure we fail and exit on the command that actually failed.
 set -e

--- a/planck-cljs/script/bundle
+++ b/planck-cljs/script/bundle
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Make sure we fail and exit on the command that actually failed.
 set -e

--- a/planck-cljs/script/bundle-c
+++ b/planck-cljs/script/bundle-c
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Run this from the planck/planck-cljs directory
 

--- a/planck-cljs/script/clean
+++ b/planck-cljs/script/clean
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 script/lein clean
 rm -rf resources
 rm -rf tools.reader

--- a/planck-cljs/script/clean-bundle
+++ b/planck-cljs/script/clean-bundle
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 rm -f manifest.m
 git update-index --no-assume-unchanged ../planck/PLKBundledOut.m

--- a/planck-cljs/script/clean-bundle-c
+++ b/planck-cljs/script/clean-bundle-c
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 rm -f bundle_dict.c
 git update-index --no-assume-unchanged ../planck-c/bundle.c

--- a/planck-cljs/script/run
+++ b/planck-cljs/script/run
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd ..
 script/run

--- a/script/build
+++ b/script/build
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #----------------------------------------------------
 # Exit if the last command failed, indicating 

--- a/script/build-c
+++ b/script/build-c
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #----------------------------------------------------
 # Exit if the last command failed, indicating 

--- a/script/build-sandbox
+++ b/script/build-sandbox
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo "{:build {:local-repo \"sandbox-m2\"}}" > planck-cljs/profiles.clj
 script/build
 rm planck-cljs/profiles.clj

--- a/script/run
+++ b/script/run
@@ -1,2 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 build/Release/planck -n 51638 -c planck-cljs/src:planck-cljs/test

--- a/site/script/build
+++ b/site/script/build
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 MARKDOWN_CLJ_VER="0.9.85"
 


### PR DESCRIPTION
I was trying to build this project on NixOS, but bash isn't located at `/bin/bash` on this distro.
So I replaced all shebang in the building scripts: `#!/bin/bash -> #!/usr/bin/env bash`.
With those modification I was able to run the scripts and get the project to compile.
