### PR TITLE
Properly track loaded foreign-libs

### DIFF
--- a/planck-cljs/src/planck/repl.cljs
+++ b/planck-cljs/src/planck/repl.cljs
@@ -877,7 +877,7 @@
   foreign-files-loaded."
   [files-to-load]
   (let [result (remove @foreign-files-loaded files-to-load)]
-    (swap! foreign-files-loaded conj result)
+    (swap! foreign-files-loaded into result)
     result))
 
 (defn- file-content


### PR DESCRIPTION
`foreign-files-loaded` would end up with lists as the elements of the
set, resulting from `conj`ing to the set. This patch changes `conj` to
`into` such that the set actually contains the loaded symbols.