### PR TITLE
remove useless `declare`

### DIFF
--- a/planck-cljs/src/planck/repl.cljs
+++ b/planck-cljs/src/planck/repl.cljs
@@ -1231,8 +1231,6 @@
   [s]
   (subs s 0 (dec (count s))))
 
-(declare print-value)
-
 (defn- format-spec
   [spec left-margin ns]
   (let [raw-print (with-out-str (print-value (s/describe spec)


### PR DESCRIPTION
`print-value` is previously declared on line 1035