### PR TITLE
Add test for POST request (JSON)

### DIFF
--- a/planck-cljs/test/planck/http_test.cljs
+++ b/planck-cljs/test/planck/http_test.cljs
@@ -159,6 +159,15 @@
   (is (= "/foo" (:uri (do-request :get "/foo"))))
   (is (= "/foo" (:uri (do-request :post "/foo")))))
 
+(deftest request-json-body-test
+  (is (= "\"foo\"" (:body (do-request :post "/" {:content-type :json
+                                                 :accept :json
+                                                 :body "\"foo\""}))))
+  (is (= "5" (get-in (do-request :post "/" {:content-type :json
+                                            :accept :json
+                                            :body "\"foo\""})
+                   [:headers "content-length"]))))
+
 (deftest http-request-debug
   (let [url              (form-full-url "/")
         expected-request (fn [method]


### PR DESCRIPTION
Unfortunately the echo server fails:

```console
curl -i -X POST \
   -H "Content-Type:application/json" \
   -H "Accept:application/json" \
   -d \
'"foo"' \
 'http://http-test.planck-repl.org/'
```

Related #503 
