### PR TITLE
Add ArchLinux Vagrantfile

### DIFF
--- a/build-envs/archlinux_64/Vagrantfile
+++ b/build-envs/archlinux_64/Vagrantfile
@@ -1,0 +1,11 @@
+Vagrant.configure(2) do |config|
+
+  config.vm.box = "terrywang/archlinux"
+
+  config.vm.provision "shell", privileged: false, inline: <<-SHELL
+    sudo pacman -Syu webkitgtk libzip zlib jdk8-openjdk base-devel git bash --needed --noconfirm
+    git clone https://aur.archlinux.org/leiningen.git
+    cd leiningen
+    makepkg -i --noconfirm
+  SHELL
+end


### PR DESCRIPTION
This Vagrantfile uses the simple, slim, terrywang/archlinux base box, with very little installed. I've made sure that base-devel and Planck's build deps are installed, as well as leiningen (which is installed from AUR). The machine is guaranteed up-to-date at time of provisioning, due to Arch's rolling release nature.