### PR TITLE
`with-sh-env` codepath subjects `env` to spec validation.

### DIFF
--- a/planck-cljs/src/planck/shell.cljs
+++ b/planck-cljs/src/planck/shell.cljs
@@ -36,6 +36,8 @@
   (let [{:keys [cmd opts cb]} (s/conform ::sh-async-args args)]
     (when (nil? cmd)
       (throw (s/explain ::sh-async-args args)))
+    (when-not (s/valid? (s/nilable ::string-string-map?) *sh-env*)
+      (throw (js/Error. (s/explain-str ::string-string-map? *sh-env*))))
     (let [{:keys [in in-enc out-enc env dir]}
           (merge {:out-enc nil :in-enc nil :dir (and *sh-dir* [:sh-dir *sh-dir*]) :env *sh-env*}
             (into {} (map (comp (juxt :key :val) second) opts)))

--- a/planck-cljs/test/planck/shell_test.cljs
+++ b/planck-cljs/test/planck/shell_test.cljs
@@ -42,6 +42,19 @@
   (let [rv (planck.shell/sh "pwd" :dir "bogus")]
     (is (not= 0 (:exit rv)))))
 
+(deftest inline-env-test
+  (is (= "FOO=BAR\n" (:out (planck.shell/sh "env" :env {"FOO" "BAR"})))))
+
 (deftest with-sh-env-test
   (is (= "FOO=BAR\n" (:out (planck.shell/with-sh-env {"FOO" "BAR"}
                              (planck.shell/sh "env"))))))
+
+(deftest with-sh-env-throws-on-nil-env-vars-test
+  (is (thrown-with-msg? js/Error
+                        #"fails spec"
+                        (planck.shell/with-sh-env {nil "value-for-a-nil-key"}
+                          (planck.shell/sh "env"))))
+  (is (thrown-with-msg? js/Error
+                        #"fails spec"
+                        (planck.shell/with-sh-env {"key-with-a-nil-value" nil}
+                          (planck.shell/sh "env")))))


### PR DESCRIPTION
Calls to `with-sh-env` are currently allowed to inject `env` maps via `planck.shell/*sh-env*` that are not subject to spec validation. 

This leads to a confusing bug whereby invocations of `with-sh-env` with `nil` values cause Planck to segfault downstream of the actual source of the bug when a shell command eventually provokes it.

This PR catches that edge case.

NB: I wrapped `s/explain-str` in `js/Error` here because that makes the most sense to me operationally (and lets us test it cleanly), though the existing spec validation just `throws` a bare `explain`. I *think* we might want to change that, since `explain` just prints to `*out*`, and thus we end up throwing a `nil`, but I'm not sure about the breaking-change situation here with regard to consumers, etc. 

