### PR TITLE
HTTP facility supports UNIX sockets

### DIFF
--- a/planck-c/http.c
+++ b/planck-c/http.c
@@ -12,6 +12,7 @@
 
 #ifndef CURL_VERSION_UNIX_SOCKETS
 #define CURL_VERSION_UNIX_SOCKETS 0
+#define CURLOPT_UNIX_SOCKET_PATH null
 #endif
 
 struct header_state {

--- a/planck-c/http.c
+++ b/planck-c/http.c
@@ -115,6 +115,14 @@ JSValueRef function_http_request(JSContextRef ctx, JSObjectRef function, JSObjec
         curl_easy_setopt(handle, CURLOPT_CUSTOMREQUEST, method);
         curl_easy_setopt(handle, CURLOPT_URL, url);
 
+        char *socket = NULL;
+        JSValueRef socket_ref = JSObjectGetProperty(ctx, opts, JSStringCreateWithUTF8CString("socket"), NULL);
+        if (!JSValueIsUndefined(ctx, socket_ref)) {
+          socket = value_to_c_string(ctx, socket_ref);
+          curl_easy_setopt(handle, CURLOPT_UNIX_SOCKET_PATH, socket);
+        }
+        free(socket);
+
         struct curl_slist *headers = NULL;
         if (!JSValueIsNull(ctx, headers_obj)) {
             JSPropertyNameArrayRef properties = JSObjectCopyPropertyNames(ctx, headers_obj);

--- a/planck-c/http.c
+++ b/planck-c/http.c
@@ -10,9 +10,18 @@
 #include "engine.h"
 #include "jsc_utils.h"
 
+#ifndef CURL_VERSION_UNIX_SOCKETS
+#define CURL_VERSION_UNIX_SOCKETS 0
+#endif
+
 struct header_state {
     JSObjectRef *headers;
 };
+
+int curl_has_feature(int feature_const) {
+  curl_version_info_data *data = curl_version_info(CURLVERSION_NOW);
+  return data->features & feature_const;
+}
 
 size_t header_to_object_callback(char *buffer, size_t size, size_t nitems, void *userdata) {
     struct header_state *state = (struct header_state *) userdata;
@@ -118,8 +127,14 @@ JSValueRef function_http_request(JSContextRef ctx, JSObjectRef function, JSObjec
         char *socket = NULL;
         JSValueRef socket_ref = JSObjectGetProperty(ctx, opts, JSStringCreateWithUTF8CString("socket"), NULL);
         if (!JSValueIsUndefined(ctx, socket_ref)) {
-          socket = value_to_c_string(ctx, socket_ref);
-          curl_easy_setopt(handle, CURLOPT_UNIX_SOCKET_PATH, socket);
+          if (curl_has_feature(CURL_VERSION_UNIX_SOCKETS)) {
+            socket = value_to_c_string(ctx, socket_ref);
+            curl_easy_setopt(handle, CURLOPT_UNIX_SOCKET_PATH, socket);
+          } else {
+            JSStringRef val_str = JSStringCreateWithUTF8CString("This version of libcurl does not support UNIX sockets.");
+            JSValueRef val_ref = JSValueMakeString(ctx, val_str);
+            return val_ref;
+          }
         }
         free(socket);
 

--- a/planck-c/http.c
+++ b/planck-c/http.c
@@ -12,7 +12,7 @@
 
 #ifndef CURL_VERSION_UNIX_SOCKETS
 #define CURL_VERSION_UNIX_SOCKETS 0
-#define CURLOPT_UNIX_SOCKET_PATH null
+#define CURLOPT_UNIX_SOCKET_PATH 0
 #endif
 
 struct header_state {

--- a/planck-cljs/src/planck/http.cljs
+++ b/planck-cljs/src/planck/http.cljs
@@ -181,7 +181,8 @@
   :debug, boolean, assoc the request on to the response
   :accepts, keyword or string. Valid keywords are :json or :xml
   :content-type, keyword or string Valid keywords are :json or :xml
-  :headers, map, a map containing headers"
+  :headers, map, a map containing headers
+  :socket, string, specifying a system path to a socket to use"
   ([url] (get url {}))
   ([url opts] (request js/PLANCK_REQUEST :get url opts)))
 
@@ -192,11 +193,13 @@
 (s/def ::headers (s/and map? (fn [m]
                                (and (every? keyword? (keys m))
                                     (every? string? (vals m))))))
+(s/def ::socket string?)
 (s/def ::body string?)
 (s/def ::status integer?)
 
 (s/fdef get
-  :args (s/cat :url string? :opts (s/? (s/keys :opt-un [::timeout ::debug ::accepts ::content-type ::headers])))
+  :args (s/cat :url string? :opts (s/? (s/keys :opt-un
+                                               [::timeout ::debug ::accepts ::content-type ::headers ::socket])))
   :ret (s/keys :req-un [::body ::headers ::status]))
 
 (defn head
@@ -209,7 +212,7 @@
   ([url opts] (request js/PLANCK_REQUEST :head url opts)))
 
 (s/fdef head
-  :args (s/cat :url string? :opts (s/? (s/keys :opt-un [::timeout ::debug ::headers])))
+  :args (s/cat :url string? :opts (s/? (s/keys :opt-un [::timeout ::debug ::headers ::socket])))
   :ret (s/keys :req-un [::headers ::status]))
 
 (defn delete
@@ -222,7 +225,7 @@
   ([url opts] (request js/PLANCK_REQUEST :delete url opts)))
 
 (s/fdef delete
-  :args (s/cat :url string? :opts (s/? (s/keys :opt-un [::timeout ::debug ::headers])))
+  :args (s/cat :url string? :opts (s/? (s/keys :opt-un [::timeout ::debug ::headers ::socket])))
   :ret (s/keys :req-un [::headers ::status]))
 
 (defn post
@@ -240,7 +243,7 @@
 
 (s/fdef post
   :args (s/cat :url string? :opts (s/? (s/keys :opt-un [::timeout ::debug ::accepts ::content-type ::headers ::body
-                                                        ::form-params ::multipart-params])))
+                                                        ::form-params ::multipart-params ::socket])))
   :ret (s/keys :req-un [::body ::headers ::status]))
 
 (defn put
@@ -255,7 +258,7 @@
 
 (s/fdef put
   :args (s/cat :url string? :opts (s/? (s/keys :opt-un [::timeout ::debug ::accepts ::content-type ::headers ::body
-                                                        ::form-params ::multipart-params])))
+                                                        ::form-params ::multipart-params ::socket])))
   :ret (s/keys :req-un [::body ::headers ::status]))
 
 (defn patch
@@ -270,7 +273,7 @@
 
 (s/fdef patch
   :args (s/cat :url string? :opts (s/? (s/keys :opt-un [::timeout ::debug ::accepts ::content-type ::headers ::body
-                                                        ::form-params ::multipart-params])))
+                                                        ::form-params ::multipart-params ::socket])))
   :ret (s/keys :req-un [::body ::headers ::status]))
 
 (repl/register-speced-vars


### PR DESCRIPTION
This PR modifies the CLJS HTTP interface and the underlying C wrapper around libcurl to add support for [UNIX sockets](https://curl.haxx.se/libcurl/c/CURLOPT_UNIX_SOCKET_PATH.html).

The use case prompting this change: talking to a socket via Planck lets us easily automate Docker using its [HTTP API](https://docs.docker.com/develop/sdk/examples/) -- particularly valuable when operating from within AWS ECS to avoid "Docker-in-Docker" woes.

I _think_ the C code here is correct, but it's been approximately forever since I've written any, so extra suspicion is appreciated. :)

