### PR TITLE
Fix Plank typos to be Planck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -413,7 +413,7 @@ All notable changes to this project will be documented in this file. This change
 ### Added
 - A quiet mode that disables banner and other output.
 - Support for `clojure.core.reducers`.
-- Ability to use `cljs.js` itself within Plank via `planck.core/init-empty-state`.
+- Ability to use `cljs.js` itself within Planck via `planck.core/init-empty-state`.
 - Autocompletion on commonly used keywords and other autocomplete improvements.
 
 ### Changed

--- a/site/src/ides.md
+++ b/site/src/ides.md
@@ -56,4 +56,4 @@ Within Cursive, add a REPL to the project and choose “Use clojure.main in norm
 (tubular.core/connect 7777)
 ```
 
-This will piggyback a Socket REPL session in the Cursive Clojure REPL, and you will see the `cljs.user=>` prompt from Planck. Use the pulldown to switch Cursive's REPL type fro `clj` to `cljs`, and you should be good to go. In particular you can use Cursive's REPL menu option to load files into Planck, sync namespaces, and send forms to the Plank REPL.
+This will piggyback a Socket REPL session in the Cursive Clojure REPL, and you will see the `cljs.user=>` prompt from Planck. Use the pulldown to switch Cursive's REPL type fro `clj` to `cljs`, and you should be good to go. In particular you can use Cursive's REPL menu option to load files into Planck, sync namespaces, and send forms to the Planck REPL.

--- a/site/src/internals.md
+++ b/site/src/internals.md
@@ -72,7 +72,7 @@ To actually read from the file, `slurp` calls another `js/PLANCK_FILE_READER_REA
 
 A few Planck ClojureScript namespaces are bundled with Planck in order to provide mappings onto these I/O primitives, exposing the simple APIs—like `slurp`—that you are familiar with: `planck.core`, `planck.io`, and `planck.shell`.
 
-In a nutshell, that’s really a big part of what Plank _is_: Some glue between ClojureScript and the native host environment.
+In a nutshell, that’s really a big part of what Planck _is_: Some glue between ClojureScript and the native host environment.
 
 ### Affordances
 


### PR DESCRIPTION
Noticed a "Plank" typo while reading internals.md and went ahead and fixed a couple other places in the source.