### PR TITLE
Handle possibility that *clojurescript-version* is nil

### DIFF
--- a/planck-cljs/src/planck/core.cljs
+++ b/planck-cljs/src/planck/core.cljs
@@ -451,17 +451,3 @@
 ;; facilities are available
 (repl/side-load-ns 'planck.http)
 (repl/side-load-ns 'planck.io)
-
-(repl/register-speced-vars
-  `exit
-  `read-line
-  `line-seq
-  `read-password
-  `file-seq
-  `slurp
-  `spit
-  `eval
-  `ns-resolve
-  `resolve
-  `intern
-  `init-empty-state)

--- a/planck-cljs/src/planck/http.cljs
+++ b/planck-cljs/src/planck/http.cljs
@@ -277,7 +277,3 @@
   :args (s/cat :url string? :opts (s/? (s/keys :opt-un [::timeout ::debug ::accepts ::content-type ::headers ::body
                                                         ::form-params ::multipart-params ::socket])))
   :ret (s/keys :req-un [::body ::headers ::status]))
-
-(repl/register-speced-vars
-  `get
-  `post)

--- a/planck-cljs/src/planck/io.cljs
+++ b/planck-cljs/src/planck/io.cljs
@@ -358,12 +358,3 @@
 (set! planck.core/*writer-fn* writer)
 (set! planck.core/*as-file-fn* as-file)
 (set! planck.core/*file?-fn* file?)
-
-(repl/register-speced-vars
-  `build-uri
-  `file?
-  `file
-  `file-attributes
-  `delete-file
-  `directory?
-  `resource)

--- a/planck-cljs/src/planck/shell.cljs
+++ b/planck-cljs/src/planck/shell.cljs
@@ -137,7 +137,3 @@
 (s/fdef sh-async
   :args ::sh-async-args
   :ret nil?)
-
-(repl/register-speced-vars
-  `sh
-  `sh-async)

--- a/planck-cljs/src/planck/socket/alpha.cljs
+++ b/planck-cljs/src/planck/socket/alpha.cljs
@@ -78,9 +78,3 @@
 (s/fdef listen
   :args (s/cat :socket ::socket :accept-handler ::accept-handler :opts (s/? ::opts))
   :ret nil?)
-
-(repl/register-speced-vars
-  `connect
-  `write
-  `close
-  `listen)


### PR DESCRIPTION
This happens when build depends on a
ClojureScript source tree.