### PR TITLE
Can't cache a namespace with spec defs

### DIFF
--- a/int-test/expected/PLANCK-OUT.txt
+++ b/int-test/expected/PLANCK-OUT.txt
@@ -108,6 +108,13 @@ nil
 :reloaded
 Test require-macros unknown ns
 No such macros namespace: unknown-ns.core, could not locate unknown_ns/core.clj or unknown_ns/core.cljc
+Test spec cache
+nil
+true
+false
+nil
+true
+false
 Test require-macros REPL special
 nil
 5

--- a/int-test/script/gen-actual
+++ b/int-test/script/gen-actual
@@ -216,6 +216,18 @@ $PLANCK -c $SRC <<REPL_INPUT
 (require-macros 'unknown-ns.core)
 REPL_INPUT
 
+echo "Test spec cache"
+$PLANCK -Kc $SRC <<REPL_INPUT
+(require 'test-cache-spec.foo)
+(test-cache-spec.foo/valid? 3)
+(test-cache-spec.foo/valid? "a")
+REPL_INPUT
+$PLANCK -Kc $SRC <<REPL_INPUT
+(require 'test-cache-spec.foo)
+(test-cache-spec.foo/valid? 3)
+(test-cache-spec.foo/valid? "a")
+REPL_INPUT
+
 echo "Test require-macros REPL special"
 $PLANCK -c $SRC <<REPL_INPUT
 (require-macros 'test-require-macros.core)

--- a/int-test/src/test_cache_spec/bar.cljs
+++ b/int-test/src/test_cache_spec/bar.cljs
@@ -1,0 +1,5 @@
+(ns test-cache-spec.bar
+  (:require
+   [clojure.spec.alpha :as s]))
+
+(s/def ::int int?)

--- a/int-test/src/test_cache_spec/foo.cljs
+++ b/int-test/src/test_cache_spec/foo.cljs
@@ -1,0 +1,7 @@
+(ns test-cache-spec.foo
+  (:require 
+   [test-cache-spec.bar :as bar]
+   [clojure.spec.alpha :as s]))
+
+(defn valid? [x]
+  (s/valid? ::bar/int x))

--- a/planck-cljs/src/planck/repl.cljs
+++ b/planck-cljs/src/planck/repl.cljs
@@ -17,6 +17,7 @@
    [cljs.tools.reader.reader-types :as rt]
    [cljsjs.parinfer]
    [clojure.string :as string]
+   [clojure.walk :as walk]
    [cognitect.transit :as transit]
    [goog.string :as gstring]
    [lazy-map.core :refer-macros [lazy-map]]
@@ -185,7 +186,11 @@
 (defn- cljs->transit-json
   [x]
   (let [wtr (transit/writer :json)]
-    (transit/write wtr x)))
+    ; postwalk identity converts map entries to work around
+    ; https://github.com/cognitect/transit-cljs/issues/33
+    (->> x
+      (walk/postwalk identity)
+      (transit/write wtr))))
 
 (defn- read-transit
   [json-file]


### PR DESCRIPTION
For #647