### PR TITLE
`io/file` should make use of `io/as-file` internally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file. This change
 - Include informative message about `-fast` when building ([#587](https://github.com/mfikes/planck/issues/587))
 - Allow HTTP response body to optionally be encoded as binary ([#649](https://github.com/mfikes/planck/issues/649))
 - Added io/make-parents ([#470](https://github.com/mfikes/planck/issues/470))
+- Added `io/as-relative-path`
 
 ### Changed
 - Use `clojure` / `deps.edn` instead of `lein` / `project.clj` when building
@@ -28,6 +29,7 @@ All notable changes to this project will be documented in this file. This change
 - Remove unnecessary equals signs between options and parameter values in help output
 - Provide more info if sh err is 126 or 127 ([#673](https://github.com/mfikes/planck/issues/673))
 - Degenerate PATH if any env map supplied to `planck.shell/sh` ([#672](https://github.com/mfikes/planck/issues/672))
+- `io/file` should make use of `io/as-file` internally ([#683](https://github.com/mfikes/planck/issues/683))
 
 ## [2.11.0] - 2018-01-23
 ### Added

--- a/planck-cljs/test/planck/io_test.cljs
+++ b/planck-cljs/test/planck/io_test.cljs
@@ -80,3 +80,16 @@
       (is (instance? Uri resource))
       (is "bundled" (.getScheme resource))
       (is (string/includes? (planck.core/slurp resource) "ns planck.repl")))))
+
+(deftest as-relative-path-test
+  (is (= "a/b/c" (planck.io/as-relative-path "a/b/c")))
+  (is (= "a/b/c" (planck.io/as-relative-path (planck.io/file "a/b/c"))))
+  (is (thrown? js/Error (planck.io/as-relative-path (planck.io/file "/a/b/c")))))
+
+(deftest file-test
+  (is (= (planck.io/file "/tmp") (planck.io/file (planck.io/file "/tmp"))))
+  (is (= (planck.io/file "/a/b") (planck.io/file "/a" "b")))
+  (is (= (planck.io/file "/a/b") (planck.io/file (planck.io/file "/a") (planck.io/file "b"))))
+  (is (= (planck.io/file "/a/b") (planck.io/file "/a" (planck.io/file "b"))))
+  (is (= (planck.io/file "/a/b") (planck.io/file (planck.io/file "/a") "b")))
+  (is (= (planck.io/file "/a/b/c") (planck.io/file "/a" "b" "c"))))

--- a/site/src/planck-io.md
+++ b/site/src/planck-io.md
@@ -14,6 +14,7 @@ _Types_
 _Vars_
 
 [as-file](#as-file)<br/>
+[as-relative-path](#as-relative-path)<br/>
 [as-url](#as-url)<br/>
 [delete-file](#delete-file)<br/>
 [directory?](#directory?)<br/>
@@ -92,6 +93,12 @@ Represents a file.
 `([x])`
 
 Coerce argument to a [`File`](#File).
+
+### <a name="as-relative-path"></a>as-relative-path
+`([x])`
+
+Take an [`as-file`](#as-file)-able thing and return a string if it is
+a relative path, else throws an exception.
   
 ### <a name="as-url"></a>as-url
 `([x])`
@@ -116,14 +123,13 @@ Spec<br/>
  _ret_: `boolean?`<br/>
  
 ### <a name="file"></a>file
-`([path] [parent & more])`
+`([arg] [parent child] [parent child & more])`
 
-Returns a [`File`](#File) for given path.  Multiple-arg
-versions treat the first argument as parent and subsequent args as
-children relative to the parent.
+Returns a [`File`](#File), passing each arg to [`as-file`](#as-file).  Multiple-arg versions treat the first argument as parent and subsequent 
+args as children relative to the parent.
 
 Spec<br/>
- _args_: `(cat :path-or-parent string? :more (* string?))`<br/>
+ _args_: `(cat :path-or-parent any? :more (* any?))`<br/>
  _ret_: `file?`
 
 ### <a name="file?"></a>file?
@@ -166,7 +172,7 @@ Given the same arg(s) as for [`file`](#file), creates all parent directories of
 the file they represent.
 
 Spec<br/>
- _args_: `(cat :path-or-parent string? :more (* string?))`<br/>
+ _args_: `(cat :path-or-parent any? :more (* any?))`<br/>
  _ret_: `boolean?`
   
 ### <a name="make-reader"></a>make-reader


### PR DESCRIPTION
Fixes #683 
adds `io/as-relative-path`